### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.6
+    hooks:
+      - id: ruff
+        args: [--fix]
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+        language_version: python3


### PR DESCRIPTION
## Summary
- set up .pre-commit-config.yaml with Ruff and Black hooks

## Testing
- `pre-commit install` *(fails: command not found, pre-commit could not be installed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68ae30c59fa88320bc75569982f7881f