### PR TITLE
Add portfolio CSV loader with validation and tests

### DIFF
--- a/ibkr_etf_rebalancer/portfolio_loader.py
+++ b/ibkr_etf_rebalancer/portfolio_loader.py
@@ -1,3 +1,118 @@
-"""Portfolio Loader module."""
+"""Utilities for loading model portfolios from CSV files."""
 
-# TODO: implement portfolio loader
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+import csv
+
+VALID_PORTFOLIOS = {"SMURF", "BADASS", "GLTR"}
+TOLERANCE = 1e-4  # 0.01%
+
+
+@dataclass
+class PortfolioRow:
+    """Single row in a portfolio CSV file."""
+
+    portfolio: str
+    symbol: str
+    target_pct: float  # stored as fraction (0-1); CASH may be negative
+
+
+class PortfolioError(ValueError):
+    """Raised when the portfolio CSV fails validation."""
+
+
+def load_portfolios(csv_path: Path, *, allow_margin: bool = False) -> Dict[str, Dict[str, float]]:
+    """Read a portfolio CSV and return a mapping of model -> weights.
+
+    Parameters
+    ----------
+    csv_path:
+        Path to the ``portfolios.csv`` file.
+    allow_margin:
+        When ``True``, allow a single ``CASH`` row per portfolio with a
+        negative percentage representing borrowed cash.
+
+    Returns
+    -------
+    dict
+        Mapping of portfolio name (e.g. ``SMURF``) to ``{symbol: weight}``
+        where ``weight`` is a fractional value (e.g. ``0.4`` for ``40``).
+
+    Raises
+    ------
+    PortfolioError
+        If the CSV is malformed or violates validation rules.
+    """
+
+    rows: list[PortfolioRow] = []
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        required = {"portfolio", "symbol", "target_pct"}
+        if reader.fieldnames is None or not required.issubset(reader.fieldnames):
+            missing = required - set(reader.fieldnames or [])
+            raise PortfolioError(
+                f"CSV missing required columns: {', '.join(sorted(missing))}"
+            )
+        for raw in reader:
+            portfolio = raw["portfolio"].strip().upper()
+            symbol = raw["symbol"].strip().upper()
+            try:
+                pct = float(raw["target_pct"]) / 100.0
+            except ValueError as exc:  # pragma: no cover - defensive
+                raise PortfolioError(
+                    f"Invalid target_pct '{raw['target_pct']}' for {portfolio}:{symbol}"
+                ) from exc
+
+            if portfolio not in VALID_PORTFOLIOS:
+                raise PortfolioError(
+                    f"Unknown portfolio '{portfolio}' (expected one of {sorted(VALID_PORTFOLIOS)})"
+                )
+
+            rows.append(PortfolioRow(portfolio, symbol, pct))
+
+    # Organize into mapping
+    portfolios: Dict[str, Dict[str, float]] = {}
+    for row in rows:
+        portfolios.setdefault(row.portfolio, {})
+        if row.symbol in portfolios[row.portfolio]:
+            if row.symbol == "CASH":
+                raise PortfolioError(
+                    f"Portfolio {row.portfolio}: multiple CASH rows found"
+                )
+            raise PortfolioError(
+                f"Duplicate symbol '{row.symbol}' in portfolio '{row.portfolio}'"
+            )
+        portfolios[row.portfolio][row.symbol] = row.target_pct
+
+    # Validate each portfolio
+    for name, weights in portfolios.items():
+        cash_values = [v for s, v in weights.items() if s == "CASH"]
+        if len(cash_values) > 1:
+            raise PortfolioError(f"Portfolio {name}: multiple CASH rows found")
+        cash_pct = cash_values[0] if cash_values else 0.0
+        asset_sum = sum(v for s, v in weights.items() if s != "CASH")
+
+        if cash_values:
+            if not allow_margin:
+                raise PortfolioError(
+                    f"Portfolio {name}: CSV contains CASH but margin is disabled"
+                )
+            if cash_pct >= 0:
+                raise PortfolioError(
+                    f"Portfolio {name}: CASH row must be negative, got {cash_pct*100:.2f}%"
+                )
+            total = asset_sum + cash_pct
+            if abs(total - 1.0) > TOLERANCE:
+                raise PortfolioError(
+                    f"Portfolio {name}: asset weights {asset_sum*100:.2f}% plus CASH {cash_pct*100:.2f}% != 100%"
+                )
+        else:
+            if abs(asset_sum - 1.0) > TOLERANCE:
+                raise PortfolioError(
+                    f"Portfolio {name}: weights sum to {asset_sum*100:.2f}% (expected 100%)"
+                )
+
+    return portfolios

--- a/srs.md
+++ b/srs.md
@@ -193,13 +193,15 @@ ibkr_etf_rebalancer/
 - Read `portfolios.csv` into a data structure: `{ 'P1': {sym: pct}, 'P2': {...}, 'P3': {...} }`.
 - Normalize to fractions (0–1) internally (keep signs for `CASH`).
 - Validation per portfolio:
-  1. Count `CASH` rows. If more than one → fail.  
+  1. Count `CASH` rows. If more than one → fail.
   2. If a `CASH` row exists:
      - Require `allow_margin=true` in config; otherwise fail with: "CSV contains CASH but margin is disabled".
      - Enforce `CASH < 0`. If `CASH ≥ 0` → fail (positive cash should be modeled by reducing asset weights).
-     - Compute `sum_assets = sum(target_pct of non‑CASH)` and verify `sum_assets + CASH ≈ 100%` (±0.01).  
+     - Compute `sum_assets = sum(target_pct of non‑CASH)` and verify `sum_assets + CASH ≈ 100%` (±0.01).
      - Compute gross = `sum_assets`. Verify `gross ≤ max_leverage × 100%` (with a small epsilon); else fail with a leverage error.
   3. If no `CASH` row: verify `sum_assets ≈ 100%` (±0.01).
+
+*Implementation note:* The current loader enforces the weight and `CASH` rules above but does **not** yet check `max_leverage`.
 
 ### 5.3 Model Blending
 - Compute final targets per symbol using model mix.

--- a/tests/test_portfolio_loader.py
+++ b/tests/test_portfolio_loader.py
@@ -1,0 +1,102 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the package root is on the import path when running tests directly
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ibkr_etf_rebalancer.portfolio_loader import load_portfolios, PortfolioError
+
+
+@pytest.fixture(
+    params=[
+        (
+            "basic",
+            """portfolio,symbol,target_pct\nSMURF,VTI,40\nSMURF,VEA,30\nSMURF,BND,30\nBADASS,USMV,60\nBADASS,QUAL,40\nGLTR,IGV,50\nGLTR,XLV,50\n""",
+            False,
+            {
+                "SMURF": {"VTI": 0.40, "VEA": 0.30, "BND": 0.30},
+                "BADASS": {"USMV": 0.60, "QUAL": 0.40},
+                "GLTR": {"IGV": 0.50, "XLV": 0.50},
+            },
+        ),
+        (
+            "with_cash",
+            """portfolio,symbol,target_pct\nSMURF,VTI,60\nSMURF,BND,40\nBADASS,SPY,100\nGLTR,GLD,100\nGLTR,GDX,50\nGLTR,CASH,-50\n""",
+            True,
+            {
+                "SMURF": {"VTI": 0.60, "BND": 0.40},
+                "BADASS": {"SPY": 1.0},
+                "GLTR": {"GLD": 1.0, "GDX": 0.50, "CASH": -0.50},
+            },
+        ),
+    ],
+    ids=lambda p: p[0],
+)
+def valid_csv(tmp_path: Path, request):
+    name, csv_content, allow_margin, expected = request.param
+    path = tmp_path / f"{name}.csv"
+    path.write_text(csv_content)
+    return path, allow_margin, expected
+
+
+def test_load_valid_csv(valid_csv):
+    path, allow_margin, expected = valid_csv
+    result = load_portfolios(path, allow_margin=allow_margin)
+    assert result == expected
+
+
+@pytest.fixture(
+    params=[
+        (
+            "sum_not_100",
+            """portfolio,symbol,target_pct\nSMURF,VTI,50\nSMURF,VEA,30\nSMURF,BND,30\n""",
+            False,
+            "weights sum to 110.00%",
+        ),
+        (
+            "cash_positive",
+            """portfolio,symbol,target_pct\nSMURF,VTI,50\nSMURF,CASH,50\n""",
+            True,
+            "CASH row must be negative",
+        ),
+        (
+            "multi_cash",
+            """portfolio,symbol,target_pct\nSMURF,VTI,100\nSMURF,CASH,-10\nSMURF,CASH,-10\n""",
+            True,
+            "multiple CASH rows",
+        ),
+        (
+            "cash_not_100",
+            """portfolio,symbol,target_pct\nSMURF,VTI,90\nSMURF,CASH,-5\n""",
+            True,
+            "asset weights 90.00% plus CASH -5.00% != 100%",
+        ),
+        (
+            "cash_without_margin",
+            """portfolio,symbol,target_pct\nSMURF,VTI,50\nSMURF,CASH,-50\n""",
+            False,
+            "margin is disabled",
+        ),
+        (
+            "unknown_portfolio",
+            """portfolio,symbol,target_pct\nFOO,VTI,100\n""",
+            False,
+            "Unknown portfolio",
+        ),
+    ],
+    ids=lambda p: p[0],
+)
+def invalid_csv(tmp_path: Path, request):
+    name, csv_content, allow_margin, message = request.param
+    path = tmp_path / f"{name}.csv"
+    path.write_text(csv_content)
+    return path, allow_margin, message
+
+
+def test_load_invalid_csv(invalid_csv):
+    path, allow_margin, message = invalid_csv
+    with pytest.raises(PortfolioError) as exc:
+        load_portfolios(path, allow_margin=allow_margin)
+    assert message in str(exc.value)


### PR DESCRIPTION
## Summary
- implement portfolio loader with dataclass, CSV parsing, and CASH/weight validations
- add table-driven unit tests for valid and invalid portfolio CSVs
- note in SRS that leverage check is not yet implemented

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae897b56c88320a33715bece48347d