### PR TITLE
test: rely on pytest import discovery

### DIFF
--- a/tests/test_portfolio_loader.py
+++ b/tests/test_portfolio_loader.py
@@ -1,10 +1,6 @@
-import sys
 from pathlib import Path
 
 import pytest
-
-# Ensure the package root is on the import path when running tests directly
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from ibkr_etf_rebalancer.portfolio_loader import load_portfolios, PortfolioError
 


### PR DESCRIPTION
## Summary
- remove manual `sys.path` adjustment in portfolio loader tests and group imports at file top

## Testing
- `ruff check tests/test_portfolio_loader.py`
- `black tests/test_portfolio_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae94d46f288320bdb46417635045be