### PR TITLE
Add pydantic configuration models and tests

### DIFF
--- a/ibkr_etf_rebalancer/config.py
+++ b/ibkr_etf_rebalancer/config.py
@@ -1,3 +1,94 @@
-"""Config module."""
+"""Application configuration using Pydantic models."""
 
-# TODO: implement config
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class IBKRConfig(BaseModel):
+    """Interactive Brokers connection settings."""
+
+    account: str = Field(..., description="IBKR account identifier")
+    host: str = Field("localhost", description="TWS/IB Gateway host")
+    port: int = Field(7497, description="TWS/IB Gateway port")
+    client_id: int = Field(1, description="Client id for the API connection")
+
+
+class ModelsConfig(BaseModel):
+    """Weights for allocation models."""
+
+    SMURF: float = Field(..., ge=0, le=1)
+    BADASS: float = Field(..., ge=0, le=1)
+    GLTR: float = Field(..., ge=0, le=1)
+
+    @model_validator(mode="after")
+    def weights_sum_to_one(self) -> "ModelsConfig":
+        total = self.SMURF + self.BADASS + self.GLTR
+        if abs(total - 1.0) > 0.001:
+            raise ValueError("Model weights must sum to 1.0 ±0.001")
+        return self
+
+
+class RebalanceConfig(BaseModel):
+    """Rebalancing behaviour flags."""
+
+    allow_fractional: bool = Field(True, description="Allow fractional share orders")
+    allow_margin: bool = Field(False, description="Permit use of margin for trades")
+
+
+class FXConfig(BaseModel):
+    """Foreign exchange settings."""
+
+    base_currency: str = Field("USD", description="Base currency for the account")
+    max_spread: float = Field(0.005, ge=0, description="Maximum acceptable FX spread")
+
+
+class LimitsConfig(BaseModel):
+    """Trading limits."""
+
+    allow_margin: bool = Field(False, description="Permit margin trading")
+    allow_fractional: bool = Field(True, description="Allow fractional shares")
+    max_leverage: float = Field(1.0, description="Maximum portfolio leverage")
+
+    @field_validator("max_leverage")
+    def positive_leverage(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError("max_leverage must be positive")
+        return v
+
+
+class SafetyConfig(BaseModel):
+    """Safety related thresholds."""
+
+    max_drawdown: float = Field(0.25, gt=0, le=1, description="Max allowable drawdown")
+
+
+class IOConfig(BaseModel):
+    """Input/output paths and options."""
+
+    output_dir: str = Field("./out", description="Directory for generated reports")
+    log_level: str = Field("INFO", description="Logging verbosity")
+
+
+class AppConfig(BaseModel):
+    """Top level application configuration."""
+
+    ibkr: IBKRConfig
+    models: ModelsConfig
+    rebalance: RebalanceConfig
+    fx: FXConfig
+    limits: LimitsConfig
+    safety: SafetyConfig
+    io: IOConfig
+
+
+__all__ = [
+    "IBKRConfig",
+    "ModelsConfig",
+    "RebalanceConfig",
+    "FXConfig",
+    "LimitsConfig",
+    "SafetyConfig",
+    "IOConfig",
+    "AppConfig",
+]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+# Ensure project root on path for direct test execution
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ibkr_etf_rebalancer.config import AppConfig
+
+
+def valid_config_dict():
+    return {
+        "ibkr": {"account": "DU123"},
+        "models": {"SMURF": 0.5, "BADASS": 0.3, "GLTR": 0.2},
+        "rebalance": {"allow_fractional": True, "allow_margin": False},
+        "fx": {"base_currency": "USD", "max_spread": 0.01},
+        "limits": {"allow_margin": False, "allow_fractional": True, "max_leverage": 1.0},
+        "safety": {"max_drawdown": 0.5},
+        "io": {"output_dir": "/tmp", "log_level": "INFO"},
+    }
+
+
+def test_valid_config():
+    cfg = AppConfig(**valid_config_dict())
+    assert cfg.models.SMURF == 0.5
+    assert cfg.limits.max_leverage == 1.0
+
+
+def test_missing_section():
+    data = valid_config_dict()
+    data.pop("fx")
+    with pytest.raises(ValidationError):
+        AppConfig(**data)
+
+
+def test_model_weights_sum():
+    data = valid_config_dict()
+    data["models"]["GLTR"] = 0.3  # total = 1.1
+    with pytest.raises(ValidationError):
+        AppConfig(**data)
+
+
+def test_invalid_max_leverage():
+    data = valid_config_dict()
+    data["limits"]["max_leverage"] = -1
+    with pytest.raises(ValidationError):
+        AppConfig(**data)
+
+
+def test_invalid_fx_spread():
+    data = valid_config_dict()
+    data["fx"]["max_spread"] = -0.01
+    with pytest.raises(ValidationError):
+        AppConfig(**data)


### PR DESCRIPTION
## Summary
- implement pydantic-based configuration models for IBKR, models, rebalance, FX, limits, safety, and I/O
- enforce model weight sums and leverage/spread validations with defaults
- add unit tests for valid configs and edge cases

## Testing
- `ruff check ibkr_etf_rebalancer/config.py tests/test_config.py`
- `mypy ibkr_etf_rebalancer/config.py tests/test_config.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae9580aebc8320b745a2a11fb765d2