### PR TITLE
Add target blending and property-based tests

### DIFF
--- a/ibkr_etf_rebalancer/target_blender.py
+++ b/ibkr_etf_rebalancer/target_blender.py
@@ -1,3 +1,90 @@
-"""Target Blender module."""
+"""Blend model portfolios into final targets.
 
-# TODO: implement target blender
+This module combines the portfolios produced by individual models
+(SMURF, BADASS, GLTR) according to the weights specified in the
+``[models]`` section of the application configuration.
+
+The blending process:
+    1. Multiply each model's asset weights by its configured mix weight.
+    2. Combine overlapping symbols by summing their contributions.
+    3. Carry any ``CASH`` row forward as a borrow indicator.
+    4. Compute gross (sum of asset weights) and net (including ``CASH``)
+       exposure and normalise the final weights so that net exposure is
+       exactly ``100%``.
+    5. Return the targets in deterministic alphabetical order for
+       stable reporting.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict, defaultdict
+from dataclasses import dataclass
+from typing import Mapping, Dict
+
+from .config import ModelsConfig
+
+
+@dataclass
+class BlendResult:
+    """Result of blending model portfolios."""
+
+    weights: "OrderedDict[str, float]"
+    """Normalised target weights per symbol (including ``CASH``)."""
+
+    gross_exposure: float
+    """Total long exposure excluding ``CASH`` (always positive)."""
+
+    net_exposure: float
+    """Net exposure after including ``CASH`` (should equal ``1.0``)."""
+
+
+def blend_targets(
+    portfolios: Mapping[str, Mapping[str, float]],
+    models: ModelsConfig,
+) -> BlendResult:
+    """Blend model portfolios according to ``models`` weights.
+
+    Parameters
+    ----------
+    portfolios:
+        Mapping of model name to ``{symbol: weight}`` dictionaries. Each
+        weight is a fractional value (e.g. ``0.25`` for ``25%``).  A
+        special ``CASH`` symbol may appear with a negative weight to
+        represent borrowed cash.
+    models:
+        ``ModelsConfig`` instance providing the mix weights for SMURF,
+        BADASS and GLTR.  The weights are expected to sum to ``1.0``.
+
+    Returns
+    -------
+    BlendResult
+        Normalised weights plus gross and net exposure figures.
+    """
+
+    # Accumulate contributions from each model
+    contributions: Dict[str, float] = defaultdict(float)
+    for model_name, model_weight in [
+        ("SMURF", models.SMURF),
+        ("BADASS", models.BADASS),
+        ("GLTR", models.GLTR),
+    ]:
+        for symbol, weight in portfolios.get(model_name, {}).items():
+            contributions[symbol] += weight * model_weight
+
+    net = sum(contributions.values())
+    if net == 0:  # pragma: no cover - defensive; portfolios validated elsewhere
+        raise ValueError("Combined portfolio has zero net exposure")
+
+    # Normalise so that net exposure equals 100%
+    for symbol in list(contributions.keys()):
+        contributions[symbol] /= net
+
+    gross = sum(w for s, w in contributions.items() if s != "CASH")
+    net = gross + contributions.get("CASH", 0.0)
+
+    ordered = OrderedDict(sorted(contributions.items()))
+
+    return BlendResult(weights=ordered, gross_exposure=gross, net_exposure=net)
+
+
+__all__ = ["BlendResult", "blend_targets"]

--- a/tests/test_target_blender.py
+++ b/tests/test_target_blender.py
@@ -1,0 +1,95 @@
+import sys
+from pathlib import Path
+
+import pytest
+from hypothesis import given, strategies as st
+
+# Ensure the package root is on the import path when running tests directly
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ibkr_etf_rebalancer.target_blender import blend_targets
+from ibkr_etf_rebalancer.config import ModelsConfig
+
+
+# Strategies -----------------------------------------------------------------
+
+
+@st.composite
+def model_weights(draw):
+    w1 = draw(st.floats(min_value=0.0, max_value=1.0))
+    w2 = draw(st.floats(min_value=0.0, max_value=1.0 - w1))
+    w3 = 1.0 - w1 - w2
+    return ModelsConfig(SMURF=w1, BADASS=w2, GLTR=w3)
+
+
+SYMBOLS = ["AAA", "BBB", "CCC", "DDD"]
+
+
+@st.composite
+def random_portfolio(draw, require_symbol: str | None = None):
+    include_cash = draw(st.booleans())
+    num_assets = draw(st.integers(min_value=1, max_value=3))
+    available = [s for s in SYMBOLS if s != require_symbol]
+    symbols = draw(
+        st.lists(st.sampled_from(available), min_size=num_assets, max_size=num_assets, unique=True)
+    )
+    if require_symbol is not None:
+        symbols = [require_symbol] + symbols
+    weights = draw(
+        st.lists(
+            st.floats(min_value=0.01, max_value=0.9),
+            min_size=len(symbols),
+            max_size=len(symbols),
+        )
+    )
+    asset_sum = sum(weights)
+    if include_cash:
+        factor = draw(st.floats(min_value=1.0001, max_value=1.5)) / asset_sum
+        weights = [w * factor for w in weights]
+        asset_sum = sum(weights)
+        cash = 1.0 - asset_sum
+        portfolio = {sym: w for sym, w in zip(symbols, weights)}
+        portfolio["CASH"] = cash
+    else:
+        factor = 1.0 / asset_sum
+        weights = [w * factor for w in weights]
+        portfolio = {sym: w for sym, w in zip(symbols, weights)}
+    return portfolio
+
+
+@st.composite
+def portfolios(draw, require_symbol: str | None = None):
+    return {
+        "SMURF": draw(random_portfolio(require_symbol=require_symbol)),
+        "BADASS": draw(random_portfolio(require_symbol=require_symbol)),
+        "GLTR": draw(random_portfolio(require_symbol=require_symbol)),
+    }
+
+
+# Property tests -------------------------------------------------------------
+
+
+@given(portfolios(), model_weights())
+def test_blend_normalizes_to_one(portfolios, weights):
+    result = blend_targets(portfolios, weights)
+    assert pytest.approx(1.0, abs=1e-9) == result.net_exposure
+    assert pytest.approx(1.0, abs=1e-9) == sum(result.weights.values())
+    # Deterministic ordering
+    assert list(result.weights.keys()) == sorted(result.weights.keys())
+
+
+@given(portfolios(require_symbol="SPY"), model_weights())
+def test_overlapping_symbols_are_combined(portfolios, weights):
+    result = blend_targets(portfolios, weights)
+    # Compute expected SPY weight
+    raw_spy = sum(
+        weights_dict.get("SPY", 0.0) * getattr(weights, model)
+        for model, weights_dict in portfolios.items()
+    )
+    raw_total = sum(
+        sum(wts.values()) * getattr(weights, model) for model, wts in portfolios.items()
+    )
+    expected_spy = raw_spy / raw_total
+    assert pytest.approx(expected_spy, rel=1e-9, abs=1e-9) == result.weights["SPY"]
+    # Only one SPY entry after blending
+    assert list(result.weights.keys()).count("SPY") == 1


### PR DESCRIPTION
## Summary
- implement deterministic blend_targets with gross/net exposure normalization
- add hypothesis property tests for normalization and symbol merging

## Testing
- `python -m black ibkr_etf_rebalancer/target_blender.py tests/test_target_blender.py`
- `ruff check ibkr_etf_rebalancer/target_blender.py tests/test_target_blender.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae96ce65708320a5373a3dbae6b745