### PR TITLE
Expand configuration models and tests per SRS

### DIFF
--- a/ibkr_etf_rebalancer/config.py
+++ b/ibkr_etf_rebalancer/config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 
@@ -30,43 +32,142 @@ class ModelsConfig(BaseModel):
 
 
 class RebalanceConfig(BaseModel):
-    """Rebalancing behaviour flags."""
+    """Rebalancing behaviour and limits.
 
-    allow_fractional: bool = Field(True, description="Allow fractional share orders")
-    allow_margin: bool = Field(False, description="Permit use of margin for trades")
+    Values mirror the SRS ``[rebalance]`` section.  Tolerance bands are
+    expressed in basis points (1/100th of a percent).
+    """
+
+    trigger_mode: Literal["per_holding", "total_drift"] = Field(
+        "per_holding",
+        description="How to decide when to trade: per holding or total portfolio drift",
+    )
+    per_holding_band_bps: int = Field(
+        50, ge=0, description="Trade a holding when its drift exceeds this many bps"
+    )
+    portfolio_total_band_bps: int = Field(
+        100, ge=0, description="Total drift trigger when trigger_mode='total_drift'"
+    )
+    min_order_usd: float = Field(
+        500, gt=0, description="Ignore trades smaller than this notional value"
+    )
+    cash_buffer_pct: float = Field(
+        1.0, ge=0, le=100, description="Hold back this percent of equity as cash"
+    )
+    allow_fractional: bool = Field(
+        False, description="Set true only if account supports fractional shares"
+    )
+    allow_margin: bool = Field(
+        False, description="Permit use of margin when CASH is negative"
+    )
+    max_leverage: float = Field(
+        1.5,
+        gt=0,
+        description="Hard cap on gross exposure as multiple of equity (e.g. 1.5 = 150%)",
+    )
+    maintenance_buffer_pct: float = Field(
+        10, ge=0, le=100, description="Headroom against margin calls in percent"
+    )
+    prefer_rth: bool = Field(
+        True, description="Place orders only during regular trading hours"
+    )
+    order_type: Literal["LMT", "MKT"] = Field(
+        "LMT", description="Default order type for rebalancing trades"
+    )
 
 
 class FXConfig(BaseModel):
-    """Foreign exchange settings."""
+    """Foreign exchange settings following SRS ``[fx]`` rules."""
 
-    base_currency: str = Field("USD", description="Base currency for the account")
-    max_spread: float = Field(0.005, ge=0, description="Maximum acceptable FX spread")
+    enabled: bool = Field(False, description="Enable FX funding of USD trades")
+    base_currency: str = Field(
+        "USD", description="Portfolio/target currency"
+    )
+    funding_currencies: list[str] = Field(
+        default_factory=lambda: ["CAD"],
+        description="Currencies available to convert from",
+    )
+    convert_mode: Literal["just_in_time", "always_top_up"] = Field(
+        "just_in_time", description="When to convert FX to fund buys"
+    )
+    use_mid_for_planning: bool = Field(
+        True, description="Size FX conversions using the mid price"
+    )
+    min_fx_order_usd: float = Field(
+        1000, gt=0, description="Skip conversions smaller than this"
+    )
+    fx_buffer_bps: int = Field(
+        20, ge=0, description="Buy a small extra cushion when converting"
+    )
+    order_type: Literal["MKT", "LMT"] = Field(
+        "MKT", description="Order type used for FX conversions"
+    )
+    limit_slippage_bps: int = Field(
+        5, ge=0, description="Slippage when order_type='LMT'"
+    )
+    route: str = Field("IDEALPRO", description="IBKR FX venue")
+    wait_for_fill_seconds: int = Field(
+        5, ge=0, description="Pause before placing dependent ETF orders"
+    )
+    prefer_market_hours: bool = Field(
+        False, description="Allow off-hours FX trading by default"
+    )
 
 
 class LimitsConfig(BaseModel):
-    """Trading limits."""
+    """Spread‑aware limit pricing settings from SRS ``[limits]``."""
 
-    allow_margin: bool = Field(False, description="Permit margin trading")
-    allow_fractional: bool = Field(True, description="Allow fractional shares")
-    max_leverage: float = Field(1.0, description="Maximum portfolio leverage")
-
-    @field_validator("max_leverage")
-    def positive_leverage(cls, v: float) -> float:
-        if v <= 0:
-            raise ValueError("max_leverage must be positive")
-        return v
+    smart_limit: bool = Field(
+        True, description="Enable dynamic spread-aware limit prices"
+    )
+    style: Literal["spread_aware", "static_bps", "off"] = Field(
+        "spread_aware", description="Pricing style"
+    )
+    buy_offset_frac: float = Field(
+        0.25, ge=0, le=1, description="BUY at mid + frac*spread"
+    )
+    sell_offset_frac: float = Field(
+        0.25, ge=0, le=1, description="SELL at mid - frac*spread"
+    )
+    max_offset_bps: int = Field(
+        10, ge=0, description="Cap distance from mid in bps"
+    )
+    wide_spread_bps: int = Field(
+        50, ge=0, description="Treat spreads wider than this as wide"
+    )
+    escalate_action: Literal["cross", "market", "keep"] = Field(
+        "cross", description="Action when spread is wide or quotes stale"
+    )
+    stale_quote_seconds: int = Field(
+        10, ge=0, description="Quote age before considered stale"
+    )
+    use_ask_bid_cap: bool = Field(
+        True, description="Never bid above ask or offer below bid"
+    )
 
 
 class SafetyConfig(BaseModel):
-    """Safety related thresholds."""
+    """Safety related thresholds and flags from SRS ``[safety]``."""
 
-    max_drawdown: float = Field(0.25, gt=0, le=1, description="Max allowable drawdown")
+    max_drawdown: float = Field(
+        0.25, gt=0, le=1, description="Max allowable drawdown"
+    )
+    paper_only: bool = Field(
+        True, description="Hard gate: only run in paper mode unless overridden"
+    )
+    require_confirm: bool = Field(
+        True, description="Prompt for confirmation before sending live orders"
+    )
+    kill_switch_file: str = Field(
+        "KILL_SWITCH",
+        description="If this file exists the program aborts immediately",
+    )
 
 
 class IOConfig(BaseModel):
     """Input/output paths and options."""
 
-    output_dir: str = Field("./out", description="Directory for generated reports")
+    report_dir: str = Field("reports", description="Directory for generated reports")
     log_level: str = Field("INFO", description="Logging verbosity")
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,18 +14,19 @@ def valid_config_dict():
     return {
         "ibkr": {"account": "DU123"},
         "models": {"SMURF": 0.5, "BADASS": 0.3, "GLTR": 0.2},
-        "rebalance": {"allow_fractional": True, "allow_margin": False},
-        "fx": {"base_currency": "USD", "max_spread": 0.01},
-        "limits": {"allow_margin": False, "allow_fractional": True, "max_leverage": 1.0},
-        "safety": {"max_drawdown": 0.5},
-        "io": {"output_dir": "/tmp", "log_level": "INFO"},
+        "rebalance": {},
+        "fx": {},
+        "limits": {},
+        "safety": {},
+        "io": {},
     }
 
 
 def test_valid_config():
     cfg = AppConfig(**valid_config_dict())
     assert cfg.models.SMURF == 0.5
-    assert cfg.limits.max_leverage == 1.0
+    assert cfg.rebalance.trigger_mode == "per_holding"
+    assert cfg.limits.style == "spread_aware"
 
 
 def test_missing_section():
@@ -44,13 +45,27 @@ def test_model_weights_sum():
 
 def test_invalid_max_leverage():
     data = valid_config_dict()
-    data["limits"]["max_leverage"] = -1
+    data["rebalance"]["max_leverage"] = -1
     with pytest.raises(ValidationError):
         AppConfig(**data)
 
 
-def test_invalid_fx_spread():
+def test_invalid_trigger_mode():
     data = valid_config_dict()
-    data["fx"]["max_spread"] = -0.01
+    data["rebalance"]["trigger_mode"] = "bad"
+    with pytest.raises(ValidationError):
+        AppConfig(**data)
+
+
+def test_invalid_limits_style():
+    data = valid_config_dict()
+    data["limits"]["style"] = "bad"
+    with pytest.raises(ValidationError):
+        AppConfig(**data)
+
+
+def test_invalid_fx_buffer():
+    data = valid_config_dict()
+    data["fx"]["fx_buffer_bps"] = -1
     with pytest.raises(ValidationError):
         AppConfig(**data)


### PR DESCRIPTION
## Summary
- expand configuration models to cover SRS [rebalance], [limits], [fx], [safety], and [io] settings
- add validation logic and defaults for new configuration options
- exercise new config defaults and validation errors in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aeab0686108320bf7061df2f5194b1