### PR TITLE
fix: close flow sequence in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: v1.11.2
     hooks:
       - id: mypy
-        args: [--strict, --config-file=pyproject.toml
+        args: [--strict, --config-file=pyproject.toml]
         additional_dependencies:
           - pandas-stubs         # pandas typing
           - pydantic>=2          # so BaseModel resolves & plugin activates


### PR DESCRIPTION
## Summary
- close the mypy hook's args list in pre-commit config

## Testing
- `pre-commit run --files .pre-commit-config.yaml` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af26cc60348320ba65fba1eac72597