### PR TITLE
Relax mypy checks for tests

### DIFF
--- a/ibkr_etf_rebalancer/reporting.py
+++ b/ibkr_etf_rebalancer/reporting.py
@@ -119,7 +119,7 @@ def generate_pre_trade_report(
     *,
     output_dir: Path | None = None,
     as_of: datetime | None = None,
-):
+) -> pd.DataFrame | tuple[pd.DataFrame, Path, Path]:
     """Create the pre‑trade report and optionally persist it to ``output_dir``.
 
     Parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,13 @@ ignore_missing_imports = true
 
 # So tests don't have to annotate every function/fixture
 [[tool.mypy.overrides]]
-module = ["tests/**/*.py", "tests/*.py"]
+# Relax typing requirements for test modules
+module = ["tests", "tests.*"]
 disallow_untyped_defs = false
 check_untyped_defs = false
 disallow_incomplete_defs = false
 warn_return_any = false
+disallow_untyped_calls = false
 
 [tool.pydantic-mypy]
 init_typed = true              # treat __init__ as typed


### PR DESCRIPTION
## Summary
- fix mypy override for tests to use proper module patterns and allow untyped calls
- annotate `generate_pre_trade_report` return type for strict mypy
- add package marker for tests

## Testing
- `pre-commit run --files pyproject.toml tests/conftest.py tests/test_config.py tests/test_portfolio_loader.py tests/test_rebalance_engine.py tests/test_reporting.py tests/test_smoke.py tests/test_target_blender.py`

------
https://chatgpt.com/codex/tasks/task_e_68af2af01c3483209b25599a34da13a7