### PR TITLE
Validate allow_margin boolean and add tests

### DIFF
--- a/ibkr_etf_rebalancer/config.py
+++ b/ibkr_etf_rebalancer/config.py
@@ -81,6 +81,7 @@ class RebalanceConfig(BaseModel):
             if val in {"false", "0", "no", "off"}:
                 return False
         raise ValueError("allow_margin must be a boolean")
+
     max_leverage: float = Field(
         1.5,
         gt=0,

--- a/ibkr_etf_rebalancer/config.py
+++ b/ibkr_etf_rebalancer/config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from configparser import ConfigParser
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, model_validator, field_validator
 
 
 class IBKRConfig(BaseModel):
@@ -60,6 +60,27 @@ class RebalanceConfig(BaseModel):
         False, description="Set true only if account supports fractional shares"
     )
     allow_margin: bool = Field(False, description="Permit use of margin when CASH is negative")
+
+    @field_validator("allow_margin", mode="before")
+    @classmethod
+    def _validate_allow_margin(cls, v: Any) -> bool:
+        """Ensure allow_margin receives a boolean value.
+
+        Accept typical string forms ("true"/"false"), integer 0/1 and bools; reject
+        anything else so negative numbers like ``-1`` do not silently coerce to
+        ``True``.
+        """
+        if isinstance(v, bool):
+            return v
+        if isinstance(v, (int, float)) and v in (0, 1):
+            return bool(v)
+        if isinstance(v, str):
+            val = v.strip().lower()
+            if val in {"true", "1", "yes", "on"}:
+                return True
+            if val in {"false", "0", "no", "off"}:
+                return False
+        raise ValueError("allow_margin must be a boolean")
     max_leverage: float = Field(
         1.5,
         gt=0,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -50,6 +50,20 @@ def test_invalid_max_leverage():
         AppConfig(**data)
 
 
+def test_invalid_allow_margin():
+    data = valid_config_dict()
+    data["rebalance"]["allow_margin"] = -1
+    with pytest.raises(ValidationError):
+        AppConfig(**data)
+
+
+def test_allow_margin_true():
+    data = valid_config_dict()
+    data["rebalance"]["allow_margin"] = True
+    cfg = AppConfig(**data)
+    assert cfg.rebalance.allow_margin is True
+
+
 def test_invalid_trigger_mode():
     data = valid_config_dict()
     data["rebalance"]["trigger_mode"] = "bad"


### PR DESCRIPTION
## Summary
- ensure `allow_margin` only accepts true/false values and doesn't silently coerce other numbers
- cover `allow_margin` validation with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af315ffb188320b27ed784a10dde51