### PR TITLE
Add post-trade report test

### DIFF
--- a/tests/golden/post_trade_report.csv
+++ b/tests/golden/post_trade_report.csv
@@ -1,0 +1,3 @@
+symbol,side,filled_shares,avg_price,notional
+AAA,BUY,100.0,10.0,1000.0
+BBB,SELL,-50.0,20.0,-1000.0


### PR DESCRIPTION
## Summary
- add post-trade report unit test with sample executions
- verify totals, notional calculations and golden CSV formatting

## Testing
- `pre-commit run --files tests/test_reporting.py tests/golden/post_trade_report.csv`
- `pytest tests/test_reporting.py`


------
https://chatgpt.com/codex/tasks/task_e_68af34ed36c88320bb36920f78cda249