### PR TITLE
Add read-only flag to IBKR config

### DIFF
--- a/ibkr_etf_rebalancer/config.py
+++ b/ibkr_etf_rebalancer/config.py
@@ -16,6 +16,7 @@ class IBKRConfig(BaseModel):
     host: str = Field("localhost", description="TWS/IB Gateway host")
     port: int = Field(7497, description="TWS/IB Gateway port")
     client_id: int = Field(1, description="Client id for the API connection")
+    read_only: bool = Field(True, description="Connect in read-only mode without submitting orders")
 
 
 class ModelsConfig(BaseModel):
@@ -207,6 +208,8 @@ def load_config(path: Path) -> AppConfig:
     ]:
         if parser.has_section(section):
             items: dict[str, Any] = dict(parser.items(section))
+            if section == "ibkr" and "read_only" in items:
+                items["read_only"] = parser.getboolean(section, "read_only")
             if section == "fx" and "funding_currencies" in items:
                 items["funding_currencies"] = [
                     s.strip() for s in items["funding_currencies"].split(",") if s.strip()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,7 @@ def test_valid_config():
     assert cfg.models.SMURF == 0.5
     assert cfg.rebalance.trigger_mode == "per_holding"
     assert cfg.limits.style == "spread_aware"
+    assert cfg.ibkr.read_only is True
 
 
 def test_missing_section():
@@ -53,6 +54,13 @@ def test_invalid_max_leverage():
 def test_invalid_allow_margin():
     data = valid_config_dict()
     data["rebalance"]["allow_margin"] = -1
+    with pytest.raises(ValidationError):
+        AppConfig(**data)
+
+
+def test_invalid_read_only():
+    data = valid_config_dict()
+    data["ibkr"]["read_only"] = "maybe"
     with pytest.raises(ValidationError):
         AppConfig(**data)
 
@@ -91,6 +99,7 @@ def test_load_config_success(tmp_path: Path):
         """
 [ibkr]
 account = DU123
+read_only = false
 
 [models]
 SMURF = 0.5
@@ -111,6 +120,7 @@ GLTR = 0.2
 
     cfg = load_config(ini)
     assert cfg.ibkr.account == "DU123"
+    assert cfg.ibkr.read_only is False
     assert cfg.models.SMURF == 0.5
 
 


### PR DESCRIPTION
## Summary
- support read-only API connections
- parse new flag from config files
- test read-only defaults and validation

## Testing
- `pre-commit run --files ibkr_etf_rebalancer/config.py tests/test_config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af3c2ac2448320a2d6e0ecf3a671ab