### PR TITLE
Round up fractional buy orders

### DIFF
--- a/ibkr_etf_rebalancer/rebalance_engine.py
+++ b/ibkr_etf_rebalancer/rebalance_engine.py
@@ -37,6 +37,7 @@ other trades and the leverage constraints.
 
 from __future__ import annotations
 
+import math
 from typing import Dict, Mapping
 
 
@@ -158,9 +159,9 @@ def generate_orders(
             # Round towards zero would leave us short on buys or long on sells
             # so we round outwards instead.
             if shares > 0:
-                shares = int(shares)
+                shares = math.ceil(shares)
             else:
-                shares = int(shares) - (1 if shares != int(shares) else 0)
+                shares = math.floor(shares)
             if shares == 0:
                 continue
         orders_shares[symbol] = shares

--- a/tests/test_rebalance_engine.py
+++ b/tests/test_rebalance_engine.py
@@ -88,3 +88,35 @@ def test_margin_leverage_scaling():
     )
     assert orders["AAA"] == 700
     assert orders["BBB"] == -200
+
+
+def test_fractional_buy_rounds_up():
+    targets = {"AAA": 0.0012}
+    current = {"AAA": 0.0}
+    orders = generate_orders(
+        targets,
+        current,
+        PRICES,
+        EQUITY,
+        bands=0.0,
+        min_order=0.0,
+        max_leverage=1.5,
+        allow_fractional=False,
+    )
+    assert orders["AAA"] == 2
+
+
+def test_fractional_sell_rounds_away_from_zero():
+    targets = {"AAA": 0.0}
+    current = {"AAA": 0.0012}
+    orders = generate_orders(
+        targets,
+        current,
+        PRICES,
+        EQUITY,
+        bands=0.0,
+        min_order=0.0,
+        max_leverage=1.5,
+        allow_fractional=False,
+    )
+    assert orders["AAA"] == -2


### PR DESCRIPTION
## Summary
- prevent under-buying by rounding positive share quantities up when fractional trading is disabled
- keep sells rounded away from zero
- add tests for fractional buy and sell rounding

## Testing
- `pre-commit run --files ibkr_etf_rebalancer/rebalance_engine.py tests/test_rebalance_engine.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af4112c2a0832096072f3fedad8b5f