### PR TITLE
Add tests for quote staleness and missing bid/ask

### DIFF
--- a/ibkr_etf_rebalancer/pricing.py
+++ b/ibkr_etf_rebalancer/pricing.py
@@ -1,3 +1,69 @@
-"""Pricing module."""
+"""Pricing helpers and quote data structures."""
 
-# TODO: implement pricing
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Protocol
+
+
+@dataclass
+class Quote:
+    """Simple market quote.
+
+    Attributes
+    ----------
+    bid:
+        Best bid price or ``None`` if unavailable.
+    ask:
+        Best ask price or ``None`` if unavailable.
+    ts:
+        Timestamp when the quote was observed.
+    """
+
+    bid: float | None
+    ask: float | None
+    ts: datetime
+
+    def mid(self) -> float:
+        """Return the mid price with fallbacks.
+
+        If both bid and ask are available the arithmetic mid is returned.  If
+        one side is missing the other side is used as a conservative mid.
+        ``ValueError`` is raised when both sides are missing.
+        """
+
+        if self.bid is not None and self.ask is not None:
+            return (self.bid + self.ask) / 2
+        if self.bid is not None:
+            return self.bid
+        if self.ask is not None:
+            return self.ask
+        raise ValueError("Quote missing bid and ask")
+
+
+class QuoteProvider(Protocol):
+    """Abstract quote provider interface."""
+
+    def get_quote(self, symbol: str) -> Quote:  # pragma: no cover - interface
+        """Return a :class:`Quote` for *symbol*."""
+
+
+def is_stale(quote: Quote, stale_quote_seconds: int, *, now: datetime | None = None) -> bool:
+    """Return ``True`` if *quote* is older than ``stale_quote_seconds``."""
+
+    current = now or datetime.now(timezone.utc)
+    return (current - quote.ts).total_seconds() > stale_quote_seconds
+
+
+class FakeQuoteProvider:
+    """Deterministic provider used for tests."""
+
+    def __init__(self, quotes: dict[str, Quote]) -> None:
+        self._quotes = quotes
+
+    def get_quote(self, symbol: str) -> Quote:
+        if symbol not in self._quotes:
+            msg = f"No quote available for {symbol}"
+            raise KeyError(msg)
+        return self._quotes[symbol]

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,39 @@
+import pytest
+from datetime import datetime, timedelta, timezone
+
+from ibkr_etf_rebalancer.pricing import Quote, is_stale, FakeQuoteProvider
+
+
+@pytest.fixture
+def fake_quote_provider() -> FakeQuoteProvider:
+    now = datetime.now(timezone.utc)
+    quotes = {
+        "FRESH": Quote(bid=100.0, ask=101.0, ts=now),
+        "STALE": Quote(bid=100.0, ask=101.0, ts=now - timedelta(seconds=20)),
+        "NOBID": Quote(bid=None, ask=101.0, ts=now),
+        "NOASK": Quote(bid=100.0, ask=None, ts=now),
+    }
+    return FakeQuoteProvider(quotes)
+
+
+def test_quote_staleness(fake_quote_provider: FakeQuoteProvider) -> None:
+    fresh = fake_quote_provider.get_quote("FRESH")
+    assert not is_stale(fresh, stale_quote_seconds=10)
+    stale = fake_quote_provider.get_quote("STALE")
+    assert is_stale(stale, stale_quote_seconds=10)
+
+
+def test_mid_fallback_for_missing_bid(fake_quote_provider: FakeQuoteProvider) -> None:
+    quote = fake_quote_provider.get_quote("NOBID")
+    assert quote.mid() == pytest.approx(101.0)
+
+
+def test_mid_fallback_for_missing_ask(fake_quote_provider: FakeQuoteProvider) -> None:
+    quote = fake_quote_provider.get_quote("NOASK")
+    assert quote.mid() == pytest.approx(100.0)
+
+
+def test_mid_raises_when_no_sides() -> None:
+    quote = Quote(bid=None, ask=None, ts=datetime.now(timezone.utc))
+    with pytest.raises(ValueError):
+        quote.mid()


### PR DESCRIPTION
## Summary
- add `Quote` helpers to pricing module with staleness check and fake provider
- test quote staleness handling and fallback for missing bid or ask

## Testing
- `pre-commit run --files ibkr_etf_rebalancer/pricing.py tests/test_pricing.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afa9d752e48320b116b47b86bee6ea