### PR TITLE
Allow Quote to accept missing bid/ask values

### DIFF
--- a/ibkr_etf_rebalancer/pricing.py
+++ b/ibkr_etf_rebalancer/pricing.py
@@ -19,8 +19,8 @@ __all__ = [
 class Quote:
     """Simple market quote."""
 
-    bid: float
-    ask: float
+    bid: float | None
+    ask: float | None
     ts: datetime
 
     def mid(self) -> float:


### PR DESCRIPTION
## Summary
- allow Quote dataclass to accept None for bid and ask
- keep existing validation of missing sides in mid() and FakeQuoteProvider

## Testing
- `pytest`
- `mypy --install-types --non-interactive .`


------
https://chatgpt.com/codex/tasks/task_e_68afd3fc90f08320a8714c3528aaa1b6