### PR TITLE
docs: expand config plan with pricing options

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -69,10 +69,11 @@ ibkr_etf_rebalancer/
 - Table‑driven tests with small CSV fixtures.
 
 ### 2.2 `config.py`
-**Goal:** Parse & validate `settings.ini` sections: `[ibkr] [models] [rebalance] [fx] [limits] [safety] [io]` and optional `[symbol_overrides]` (see SRS).
+**Goal:** Parse & validate `settings.ini` sections: `[ibkr] [models] [rebalance] [fx] [limits] [safety] [pricing] [io]` and optional `[symbol_overrides]` (see SRS).
 **Tests:**
 - Model weights sum to 1.0 (SMURF/BADASS/GLTR).
 - Guard `allow_margin`, `max_leverage`, spread‑aware params, FX knobs.
+- Validate `[pricing]` options: `price_source` chain and `fallback_to_snapshot` toggle.
 - Parse/validate optional `[symbol_overrides]` mapping.
 - Defaults and helpful error messages.
 


### PR DESCRIPTION
## Summary
- document `[pricing]` settings in the configuration plan
- cover `price_source` and `fallback_to_snapshot` in test list

## Testing
- `pre-commit run --files plan.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afdd810a60832098fb7002b61fa577