### PR TITLE
Enforce buffer constraints in rebalancing engine

### DIFF
--- a/ibkr_etf_rebalancer/rebalance_engine.py
+++ b/ibkr_etf_rebalancer/rebalance_engine.py
@@ -150,9 +150,7 @@ def generate_orders(
     cash_buffer = total_equity * cash_buffer_pct / 100.0
     maint_buffer = total_equity * maintenance_buffer_pct / 100.0
     available_leverage = max_leverage * total_equity - gross - maint_buffer
-    available_cash = (
-        cash - cash_buffer if cash_buffer_pct > 0 else float("inf")
-    )
+    available_cash = cash - cash_buffer if cash_buffer_pct > 0 else float("inf")
     available = min(available_leverage, available_cash)
     total_buy_value = sum(buys.values())
     scale = 1.0

--- a/plan.md
+++ b/plan.md
@@ -85,12 +85,12 @@ ibkr_etf_rebalancer/
 - Normalization invariants (Hypothesis property tests).
 
 ### 2.4 `rebalance_engine.py` (math only)
-**Goal:** Given targets, current weights (passed in), tolerance bands, leverage, min order USD, fractional flag → **trade plan** (no orders yet).  
+**Goal:** Given targets, current weights (passed in), tolerance bands, leverage, min order USD, fractional flag, and account buffers (`cash_buffer_pct`, `maintenance_buffer_pct`) → **trade plan** (no orders yet).
 **Tests:**
 - No trades when |drift| ≤ band.
 - Overweight/underweight scenarios, min order filtering.
 - Margin via `CASH=-50` (gross 150%), leverage cap enforced.
-- Simulated scaling of buys after sells due to buying‑power limits (logic only).
+- Simulated scaling of buys after sells due to buying‑power limits, honoring `cash_buffer_pct` and `maintenance_buffer_pct`.
 
 ### 2.5 `reporting.py`
 **Goal:** Pre‑trade report (CSV/Markdown); post‑trade skeleton.  

--- a/tests/test_rebalance_engine.py
+++ b/tests/test_rebalance_engine.py
@@ -120,3 +120,39 @@ def test_fractional_sell_rounds_away_from_zero():
         allow_fractional=False,
     )
     assert orders["AAA"] == -2
+
+
+def test_cash_buffer_limits_buys():
+    targets = {"AAA": 0.6, "BBB": 0.4, "CASH": 0.0}
+    current = {"AAA": 0.5, "BBB": 0.5, "CASH": 0.0}
+    orders = generate_orders(
+        targets,
+        current,
+        PRICES,
+        EQUITY,
+        bands=0.0,
+        min_order=0.0,
+        max_leverage=1.5,
+        cash_buffer_pct=5.0,
+        allow_fractional=False,
+    )
+    assert orders["BBB"] == -100
+    assert orders["AAA"] == 50
+
+
+def test_maintenance_buffer_limits_leverage():
+    targets = {"AAA": 1.3, "BBB": 0.3, "CASH": -0.6}
+    current = {"AAA": 0.5, "BBB": 0.5, "CASH": 0.0}
+    orders = generate_orders(
+        targets,
+        current,
+        PRICES,
+        EQUITY,
+        bands=0.0,
+        min_order=0.0,
+        max_leverage=1.5,
+        maintenance_buffer_pct=10.0,
+        allow_fractional=False,
+    )
+    assert orders["BBB"] == -200
+    assert orders["AAA"] == 600


### PR DESCRIPTION
## Summary
- Mention cash and maintenance buffers in Phase 1 planning
- Apply cash_buffer_pct and maintenance_buffer_pct in rebalance_engine.generate_orders
- Test that cash and maintenance buffers restrict buy sizing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afdf0ac33083208ed662b1a625c99d