### PR TITLE
docs: plan for Makefile-driven dev tasks

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -49,6 +49,11 @@ ibkr_etf_rebalancer/
 - Create repo, `requirements.txt`, `pyproject.toml`/`setup.cfg`.
 - Add `pre-commit` with `ruff`, `black`.
 - Add GitHub Actions workflow for lint/type/test.
+- Create `Makefile` or `invoke` tasks wrapping `ruff`, `mypy`, `pytest`, and sample run commands.
+  Example:
+  ```bash
+  make lint test run
+  ```
 - Add empty modules with docstrings and TODOs.
 
 **No external calls** yet.


### PR DESCRIPTION
## Summary
- note Makefile/invoke tasks for running lint, type checking, tests and sample commands
- show example `make lint test run`

## Testing
- `pre-commit run --files plan.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afe062a8108320abe2332b7f961670