### PR TITLE
Validate side in limit price calculation

### DIFF
--- a/ibkr_etf_rebalancer/limit_pricer.py
+++ b/ibkr_etf_rebalancer/limit_pricer.py
@@ -130,7 +130,9 @@ def calc_limit_price(
     side_u = side.upper()
     if side_u == "BUY":
         price, order_type = price_limit_buy(quote, tick, cfg, now)
-    else:
+    elif side_u == "SELL":
         price, order_type = price_limit_sell(quote, tick, cfg, now)
+    else:
+        raise ValueError("Side must be 'BUY' or 'SELL'")
 
     return (price if order_type == "LMT" else None), order_type

--- a/tests/test_limit_pricer.py
+++ b/tests/test_limit_pricer.py
@@ -160,6 +160,14 @@ def test_calc_limit_price_wrapper():
     assert t == "MKT" and price is None
 
 
+def test_calc_limit_price_invalid_side():
+    now = datetime.now(timezone.utc)
+    provider = FakeQuoteProvider({"SYM": Quote(100, 100.1, now)})
+    cfg = LimitsConfig()
+    with pytest.raises(ValueError, match="BUY.*SELL"):
+        calc_limit_price("HOLD", "SYM", 0.01, provider, now, cfg)
+
+
 @pytest.mark.parametrize(
     "func,bid,ask",
     [


### PR DESCRIPTION
## Summary
- ensure `calc_limit_price` rejects unsupported order sides
- cover invalid side with new unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afe23d190883208b5d4149b92d777f