### PR TITLE
docs: highlight pure planning logic

### DIFF
--- a/workflow.md
+++ b/workflow.md
@@ -10,6 +10,7 @@ This guide summarizes how to use `srs.md` and `plan.md` with Codex to build the 
 - Conventional commits (e.g., `feat(loader): add CASH row validation`).
 
 ## 2) CI & Guardrails
+- Keep planning logic pure; isolate IBKR/IO interactions.
 - CI runs on every push/PR: `ruff`, `black --check`, `mypy`, `pytest`.
 - DoD per PR:
   - Tests ≥90% diff coverage


### PR DESCRIPTION
## Summary
- note to keep planning logic pure and separate IBKR/IO interactions

## Testing
- `ruff check .`
- `black --check .`
- `mypy .` *(fails: command hung)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afe26c5e148320a36444ce8e8f4806