### PR TITLE
Return None for market escalation

### DIFF
--- a/tests/test_limit_pricer.py
+++ b/tests/test_limit_pricer.py
@@ -92,7 +92,7 @@ def test_wide_or_stale_escalation(bid, ask, delta, action, exp, t):
     p, ot = price_limit_buy(q, 0.01, cfg, datetime.now(timezone.utc))
     assert ot == t
     if t == "MKT":
-        assert p == 0
+        assert p is None
     else:
         assert p == pytest.approx(exp)
 
@@ -121,7 +121,7 @@ def test_sell_wide_or_stale_escalation(bid, ask, delta, action, exp, t):
     p, ot = price_limit_sell(q, 0.01, cfg, datetime.now(timezone.utc))
     assert ot == t
     if t == "MKT":
-        assert p == 0
+        assert p is None
     else:
         assert p == pytest.approx(exp)
 


### PR DESCRIPTION
## Summary
- Update limit price helpers to emit `(None, "MKT")` when escalation strategy is `market`
- Simplify `calc_limit_price` to return helper output directly
- Adjust tests for market escalation expectations

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afe30e46c48320ac126a4f1aec83f1