### PR TITLE
Add keep escalation tests for sell pricing

### DIFF
--- a/tests/test_limit_pricer.py
+++ b/tests/test_limit_pricer.py
@@ -102,8 +102,10 @@ def test_wide_or_stale_escalation(bid, ask, delta, action, exp, t):
     [
         (99, 101, 0, "cross", 99, "LMT"),
         (99, 101, 0, "market", None, "MKT"),
+        (99, 101, 0, "keep", 99.9, "LMT"),
         (99.85, 100.15, 20, "cross", 99.85, "LMT"),
         (99.85, 100.15, 20, "market", None, "MKT"),
+        (99.85, 100.15, 20, "keep", 99.92, "LMT"),
     ],
 )
 def test_sell_wide_or_stale_escalation(bid, ask, delta, action, exp, t):


### PR DESCRIPTION
## Summary
- cover "keep" escalation in sell side wide/stale tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afe3f57804832095eb67a52e93c090