### PR TITLE
Support configurable price sources with snapshot fallback

### DIFF
--- a/ibkr_etf_rebalancer/pricing.py
+++ b/ibkr_etf_rebalancer/pricing.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Protocol
+from typing import Literal, Protocol
 
 
 __all__ = [
@@ -27,6 +27,7 @@ class Quote:
     bid: float | None
     ask: float | None
     ts: datetime
+    last: float | None = None
 
     def mid(self) -> float:
         """Return the arithmetic mid price."""
@@ -46,6 +47,14 @@ class QuoteProvider(Protocol):
     def get_quote(self, symbol: str) -> Quote:  # pragma: no cover - interface
         """Return a :class:`Quote` for *symbol*."""
 
+    def get_price(
+        self,
+        symbol: str,
+        price_source: Literal["last", "midpoint", "bidask"],
+        fallback_to_snapshot: bool = False,
+    ) -> float:  # pragma: no cover - interface
+        """Return a price for *symbol* using *price_source* with fallbacks."""
+
 
 def is_stale(quote: Quote, now: datetime, stale_quote_seconds: int) -> bool:
     """Return ``True`` if *quote* is older than ``stale_quote_seconds``."""
@@ -56,8 +65,9 @@ def is_stale(quote: Quote, now: datetime, stale_quote_seconds: int) -> bool:
 class FakeQuoteProvider:
     """Deterministic provider used for tests."""
 
-    def __init__(self, quotes: dict[str, Quote]) -> None:
+    def __init__(self, quotes: dict[str, Quote], snapshots: dict[str, float] | None = None) -> None:
         self._quotes = quotes
+        self._snapshots = snapshots or {}
 
     def get_quote(self, symbol: str) -> Quote:
         if symbol not in self._quotes:
@@ -69,3 +79,39 @@ class FakeQuoteProvider:
         if quote.ask is None:
             raise ValueError(f"Quote for {symbol} missing ask")
         return quote
+
+    def get_price(
+        self,
+        symbol: str,
+        price_source: Literal["last", "midpoint", "bidask"],
+        fallback_to_snapshot: bool = False,
+    ) -> float:
+        if symbol not in self._quotes:
+            msg = f"No quote available for {symbol}"
+            raise KeyError(msg)
+        quote = self._quotes[symbol]
+
+        chain = ["last", "midpoint", "bidask"]
+        if price_source not in chain:
+            raise ValueError("price_source must be 'last', 'midpoint', or 'bidask'")
+        idx = chain.index(price_source)
+        ordered = chain[idx:] + chain[:idx]
+
+        for src in ordered:
+            if src == "last" and quote.last is not None:
+                return quote.last
+            if src == "midpoint":
+                try:
+                    return quote.mid()
+                except ValueError:
+                    pass
+            if src == "bidask":
+                if quote.bid is not None:
+                    return quote.bid
+                if quote.ask is not None:
+                    return quote.ask
+
+        if fallback_to_snapshot and symbol in self._snapshots:
+            return self._snapshots[symbol]
+
+        raise ValueError(f"No price available for {symbol}")


### PR DESCRIPTION
## Summary
- extend quote provider to select prices from last, midpoint, or bid/ask with snapshot fallback
- add pricing config options for price_source and fallback_to_snapshot
- test fallback chain and snapshot retrieval

## Testing
- `pre-commit run --files ibkr_etf_rebalancer/pricing.py ibkr_etf_rebalancer/config.py tests/test_pricing.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afe6913a248320a74ec1b3315a0fda