### PR TITLE
Tick-align crossed limit prices

### DIFF
--- a/ibkr_etf_rebalancer/limit_pricer.py
+++ b/ibkr_etf_rebalancer/limit_pricer.py
@@ -72,7 +72,7 @@ def price_limit_buy(
     if wide_or_stale:
         action = cfg.escalate_action
         if action == "cross":
-            return ask, "LMT"
+            return _round_to_tick(ask, min_tick), "LMT"
         if action == "market":
             return None, "MKT"
         # action == "keep" simply keeps the capped price
@@ -113,7 +113,7 @@ def price_limit_sell(
     if wide_or_stale:
         action = cfg.escalate_action
         if action == "cross":
-            return bid, "LMT"
+            return _round_to_tick(bid, min_tick), "LMT"
         if action == "market":
             return None, "MKT"
 

--- a/tests/test_limit_pricer.py
+++ b/tests/test_limit_pricer.py
@@ -132,6 +132,34 @@ def test_sell_wide_or_stale_escalation(bid, ask, delta, action, exp, t):
         assert p == pytest.approx(exp)
 
 
+@pytest.mark.parametrize(
+    "func,bid,ask,tick,exp",
+    [
+        (
+            price_limit_buy,
+            99.9,
+            100.013,
+            0.005,
+            round(100.013 / 0.005) * 0.005,
+        ),
+        (
+            price_limit_sell,
+            99.987,
+            100.1,
+            0.005,
+            round(99.987 / 0.005) * 0.005,
+        ),
+    ],
+)
+def test_cross_rounds_non_tick_aligned(func, bid, ask, tick, exp):
+    """Cross escalation should tick align raw bid/ask prices."""
+    now = datetime.now(timezone.utc)
+    q = Quote(bid, ask, now)
+    cfg = LimitsConfig(wide_spread_bps=0, escalate_action="cross")
+    p, t = func(q, tick, cfg, now)
+    assert t == "LMT" and p == pytest.approx(exp)
+
+
 def test_tick_fallback_rounding():
     now = datetime.now(timezone.utc)
     q = Quote(100.0, 100.1, now)


### PR DESCRIPTION
## Summary
- Ensure `price_limit_buy` and `price_limit_sell` round crossed quotes to the contract's tick size
- Test non-tick-aligned quotes to confirm cross escalation uses tick rounding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afebd841a88320abbacf8f3d01b6d2