### PR TITLE
Add symbol overrides configuration

### DIFF
--- a/ibkr_etf_rebalancer/config.py
+++ b/ibkr_etf_rebalancer/config.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from configparser import ConfigParser
 from typing import Any, Literal
 
+
+SymbolOverrides = dict[str, str | int]
+
 from pydantic import BaseModel, Field, model_validator, field_validator
 
 
@@ -187,6 +190,7 @@ class AppConfig(BaseModel):
     pricing: PricingConfig = Field(default_factory=PricingConfig)
     safety: SafetyConfig
     io: IOConfig
+    symbol_overrides: SymbolOverrides = Field(default_factory=dict)
 
 
 def load_config(path: Path) -> AppConfig:
@@ -219,6 +223,7 @@ def load_config(path: Path) -> AppConfig:
         "limits",
         "safety",
         "io",
+        "symbol_overrides",
     ]:
         if parser.has_section(section):
             items: dict[str, Any] = dict(parser.items(section))
@@ -230,6 +235,15 @@ def load_config(path: Path) -> AppConfig:
                 items["funding_currencies"] = [
                     s.strip() for s in items["funding_currencies"].split(",") if s.strip()
                 ]
+            if section == "symbol_overrides":
+                converted: dict[str, Any] = {}
+                for k, v in items.items():
+                    v_str = v.strip()
+                    try:
+                        converted[k] = int(v_str)
+                    except ValueError:
+                        converted[k] = v_str
+                items = converted
             data[section] = items
 
     return AppConfig(**data)
@@ -244,6 +258,7 @@ __all__ = [
     "PricingConfig",
     "SafetyConfig",
     "IOConfig",
+    "SymbolOverrides",
     "AppConfig",
     "load_config",
 ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -93,6 +93,76 @@ def test_invalid_fx_buffer():
         AppConfig(**data)
 
 
+def test_symbol_overrides_parsing(tmp_path: Path):
+    ini = tmp_path / "config.ini"
+    ini.write_text(
+        """
+[ibkr]
+account = DU123
+
+[models]
+SMURF = 0.5
+BADASS = 0.3
+GLTR = 0.2
+
+[rebalance]
+
+[fx]
+
+[limits]
+
+[safety]
+
+[io]
+
+[symbol_overrides]
+GBTC = BTC
+FUND = 1234
+"""
+    )
+
+    cfg = load_config(ini)
+    assert cfg.symbol_overrides == {"GBTC": "BTC", "FUND": 1234}
+
+
+def test_symbol_overrides_validation():
+    data = valid_config_dict()
+    data["symbol_overrides"] = {"GBTC": 1.23}
+    with pytest.raises(ValidationError):
+        AppConfig(**data)
+
+
+def test_symbol_overrides_absent(tmp_path: Path):
+    cfg = AppConfig(**valid_config_dict())
+    assert cfg.symbol_overrides == {}
+
+    ini = tmp_path / "config.ini"
+    ini.write_text(
+        """
+[ibkr]
+account = DU123
+
+[models]
+SMURF = 0.5
+BADASS = 0.3
+GLTR = 0.2
+
+[rebalance]
+
+[fx]
+
+[limits]
+
+[safety]
+
+[io]
+"""
+    )
+
+    cfg2 = load_config(ini)
+    assert cfg2.symbol_overrides == {}
+
+
 def test_load_config_success(tmp_path: Path):
     ini = tmp_path / "config.ini"
     ini.write_text(


### PR DESCRIPTION
## Summary
- add optional `symbol_overrides` mapping to `AppConfig`
- parse `[symbol_overrides]` from INI files and coerce numeric values to integers
- test symbol overrides parsing, validation, and absence

## Testing
- `python -m pytest tests/test_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aff05e1ec483209b51c361c2a9c806