### PR TITLE
chore: add makefile for common tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: lint type test run
+
+lint:
+	ruff check .
+	black --check .
+
+type:
+	mypy .
+
+test:
+	pytest -q
+
+run:
+	python ibkr_etf_rebalancer/app.py $(ARGS)
+

--- a/workflow.md
+++ b/workflow.md
@@ -56,10 +56,11 @@ Use the provided wrappers to keep linting, testing, and running consistent acros
 ruff check . && black --check . && mypy . && pytest -q
 python app.py --csv portfolios.csv --ini settings.ini --dry-run
 
-# or via Make/Invoke helpers
+# or via Make helpers
 make lint
+make type
 make test
-invoke run --csv portfolios.csv --ini settings.ini --dry-run
+make run ARGS="--csv portfolios.csv --ini settings.ini --dry-run"
 ```
 
 These wrappers centralize the lint/test/run commands so the same checks run everywhere.


### PR DESCRIPTION
## Summary
- add Makefile wrapping lint, type, test, and run commands
- document make targets in workflow guide

## Testing
- `make lint`
- `make type`
- `make test`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68aff07c4c288320ab97149060d65cba