### PR TITLE
fix: reorder imports to satisfy ruff E402 in config

### DIFF
--- a/ibkr_etf_rebalancer/config.py
+++ b/ibkr_etf_rebalancer/config.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 from configparser import ConfigParser
 from typing import Any, Literal
+from pydantic import BaseModel, Field, model_validator, field_validator
 
 
 SymbolOverrides = dict[str, str | int]
-
-from pydantic import BaseModel, Field, model_validator, field_validator
 
 
 class IBKRConfig(BaseModel):


### PR DESCRIPTION
## Summary
- move Pydantic import above SymbolOverrides type alias in config to satisfy lint

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aff1742b588320938258b5e191eba0