### PR TITLE
Filter scaled buys below min notional

### DIFF
--- a/ibkr_etf_rebalancer/rebalance_engine.py
+++ b/ibkr_etf_rebalancer/rebalance_engine.py
@@ -163,6 +163,11 @@ def generate_orders(
         gross += scaled_value
         orders_value[symbol] = scaled_value
 
+    # Drop any orders that fell below ``min_order`` after scaling
+    orders_value = {sym: val for sym, val in orders_value.items() if abs(val) >= min_order}
+    if not orders_value:
+        return {}
+
     # ------------------------------------------------------------------
     # Convert notional values to share counts
     orders_shares: Dict[str, float] = {}

--- a/tests/test_rebalance_engine.py
+++ b/tests/test_rebalance_engine.py
@@ -73,6 +73,22 @@ def test_min_order_filtering():
     assert orders == {}
 
 
+def test_scaled_buy_dropped_below_min_order():
+    targets = {"AAA": 0.006, "CASH": 0.0}
+    current = {"AAA": 0.0, "CASH": 0.012}
+    orders = generate_orders(
+        targets,
+        current,
+        PRICES,
+        EQUITY,
+        bands=0.0,
+        min_order=500.0,
+        max_leverage=1.5,
+        cash_buffer_pct=0.8,
+    )
+    assert orders == {}
+
+
 def test_margin_leverage_scaling():
     targets = {"AAA": 1.3, "BBB": 0.3, "CASH": -0.6}
     current = {"AAA": 0.5, "BBB": 0.5, "CASH": 0.0}


### PR DESCRIPTION
## Summary
- drop orders below `min_order` after buy scaling
- regression test for scaled buys that fall under `min_order`

## Testing
- `pre-commit run --files ibkr_etf_rebalancer/rebalance_engine.py tests/test_rebalance_engine.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aff1c800a48320aba5cf2609768e8e