### PR TITLE
fix: order imports at top of config

### DIFF
--- a/ibkr_etf_rebalancer/config.py
+++ b/ibkr_etf_rebalancer/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from configparser import ConfigParser
 from typing import Any, Literal
-from pydantic import BaseModel, Field, model_validator, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 SymbolOverrides = dict[str, str | int]


### PR DESCRIPTION
## Summary
- reorder Pydantic import to top of module before declaring SymbolOverrides type alias

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aff31534388320aea8fac5d706cb8c