### PR TITLE
Add fractional rounding scenario to Phase 7 plan

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -230,6 +230,7 @@ ibkr_etf_rebalancer/
 4. Margin via `CASH=-50` (gross 150%), leverage guard.
 5. FX funding from CAD to USD first.
 6. Spread‑aware limits, wide/stale escalation.
+7. Disable `allow_fractional`, verify shares are rounded and residual drift ≤10 bps (SRS scenario test #4).
 
 **Assertions:**
 - Acceptance criteria from the SRS (margin, FX funding, spread‑aware limits, safety).


### PR DESCRIPTION
## Summary
- document end-to-end scenario for rounding when fractional shares disabled referencing SRS scenario test #4

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0730d44d48320aec7dbb692378291