### PR TITLE
docs: add performance guardrails

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -20,6 +20,13 @@ This is a concrete, test‑first roadmap for building the **IBKR ETF Portfolio R
 3. Clear docstrings + README/SRS section updated if behavior changes.
 4. Deterministic tests (use `freezegun` for timestamps).
 
+### Performance constraints
+- Full rebalance run should complete in under 30 s.
+- Limit concurrent quote fetches to a safe 4–6 range.
+- Apply retries with backoff on transient IBKR errors.
+
+> See SRS §10 for detailed performance & reliability requirements.
+
 **Repo layout (target):**
 ```
 ibkr_etf_rebalancer/

--- a/workflow.md
+++ b/workflow.md
@@ -20,6 +20,14 @@ This guide summarizes how to use `srs.md` and `plan.md` with Codex to build the 
     - Example: `feat(snapshot): track NetLiq [AC3]`
   - No secrets committed
   - Safety rails intact (paper_only, LMT default, RTH, require_confirm, kill_switch_file, prefer_rth)
+  - Benchmark runtime & quote concurrency; ensure <30 s, safe 4–6 quote fetches, and retry/backoff strategy
+
+### Performance constraints
+- Full rebalance run should complete in under 30 s.
+- Limit concurrent quote fetches to roughly 4–6 to avoid pacing.
+- Apply retries with backoff on transient IBKR errors.
+
+> These expectations come from SRS §10.
 
 ## 3) Task Card Template (paste into Codex prompt)
 **Task:** Implement `<module>` per SRS (paste relevant subsection only).  


### PR DESCRIPTION
## Summary
- document performance constraints: <30s runtime, safe quote concurrency, retry with backoff
- remind contributors in workflow to benchmark and uphold these limits

## Testing
- `make lint`
- `make type`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b073eab52883208662272d066e300e