### PR TITLE
Fix indentation for black language_version in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: 25.1.0
     hooks:
       - id: black
-       language_version: python3
+        language_version: python3
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.11.2
     hooks:


### PR DESCRIPTION
## Summary
- indent `language_version` for black hook by two extra spaces

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68b0778ab2888320be16de0d049c05f9