### PR TITLE
Normalize model config keys to uppercase

### DIFF
--- a/ibkr_etf_rebalancer/config.py
+++ b/ibkr_etf_rebalancer/config.py
@@ -226,6 +226,8 @@ def load_config(path: Path) -> AppConfig:
     ]:
         if parser.has_section(section):
             items: dict[str, Any] = dict(parser.items(section))
+            if section == "models":
+                items = {k.upper(): v for k, v in items.items()}
             if section == "ibkr" and "read_only" in items:
                 items["read_only"] = parser.getboolean(section, "read_only")
             if section == "pricing" and "fallback_to_snapshot" in items:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -214,6 +214,66 @@ GLTR = 0.2
     assert cfg.models.SMURF == 0.5
 
 
+def test_load_config_lowercase_models(tmp_path: Path):
+    ini = tmp_path / "config.ini"
+    ini.write_text(
+        """
+[ibkr]
+account = DU123
+
+[models]
+smurf = 0.5
+badass = 0.3
+gltr = 0.2
+
+[rebalance]
+
+[fx]
+
+[limits]
+
+[safety]
+
+[io]
+"""
+    )
+
+    cfg = load_config(ini)
+    assert cfg.models.SMURF == 0.5
+    assert cfg.models.BADASS == 0.3
+    assert cfg.models.GLTR == 0.2
+
+
+def test_load_config_mixed_case_models(tmp_path: Path):
+    ini = tmp_path / "config.ini"
+    ini.write_text(
+        """
+[ibkr]
+account = DU123
+
+[models]
+SmUrF = 0.5
+BaDaSs = 0.3
+gLtR = 0.2
+
+[rebalance]
+
+[fx]
+
+[limits]
+
+[safety]
+
+[io]
+"""
+    )
+
+    cfg = load_config(ini)
+    assert cfg.models.SMURF == 0.5
+    assert cfg.models.BADASS == 0.3
+    assert cfg.models.GLTR == 0.2
+
+
 def test_load_config_missing_section(tmp_path: Path):
     ini = tmp_path / "config.ini"
     ini.write_text(


### PR DESCRIPTION
## Summary
- Normalize `[models]` section keys to uppercase in `load_config` so model weights are parsed regardless of case
- Test config loading with lowercase and mixed-case model names

## Testing
- `pre-commit run --files ibkr_etf_rebalancer/config.py tests/test_config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0790bf0d08320af79696f60b9b6af