### PR TITLE
docs: reference SRS dataclass templates

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -62,6 +62,7 @@ ibkr_etf_rebalancer/
   make lint test run
   ```
 - Add empty modules with docstrings and TODOs.
+- When creating modules, follow [SRS §7 Data Structures (suggested)](srs.md#7-data-structures-suggested) for dataclass templates.
 
 **No external calls** yet.
 


### PR DESCRIPTION
## Summary
- remind developers to follow SRS §7 data structures when creating modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b07b198cfc8320a5dae01fb9f91ff8