### PR TITLE
Document gross leverage validation in plan

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -79,7 +79,9 @@ ibkr_etf_rebalancer/
 - Valid CSV: each portfolio sums to 100% or `assets + CASH = 100%` when margin used.
 - Exactly one `CASH` row allowed (if present) and must be negative.
 - Error if a `CASH` row exists while `[rebalance].allow_margin` is false.
+- Reject portfolios whose asset totals exceed `[rebalance].max_leverage × 100%`.
 - Helpful error messages on violations.
+- Table-driven fixtures demonstrating valid/invalid gross leverage.
 - Table‑driven tests with small CSV fixtures.
 
 ### 2.2 `config.py`


### PR DESCRIPTION
## Summary
- Note that portfolios exceeding `[rebalance].max_leverage` must be rejected
- Add table-driven fixtures for valid and invalid gross leverage cases

## Testing
- `make lint`
- `make type`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b07c80882c83208a279e94512121d1