### PR TITLE
test: remove per-test sys.path tweaks

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,13 +1,9 @@
-import sys
 from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
 
 from ibkr_etf_rebalancer.config import AppConfig, load_config
-
-# Ensure project root on path for direct test execution
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 
 def valid_config_dict():

--- a/tests/test_portfolio_loader.py
+++ b/tests/test_portfolio_loader.py
@@ -1,12 +1,8 @@
-import sys
 from pathlib import Path
 
 import pytest
 
 from ibkr_etf_rebalancer.portfolio_loader import load_portfolios, PortfolioError
-
-# Ensure the package root is on the import path when running tests directly
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 
 @pytest.fixture(

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,4 +1,3 @@
-import sys
 from pathlib import Path
 
 from freezegun import freeze_time
@@ -7,9 +6,6 @@ from ibkr_etf_rebalancer.reporting import (
     generate_post_trade_report,
     generate_pre_trade_report,
 )
-
-# Ensure project root on path for direct test execution
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 
 def test_pre_trade_report(tmp_path):

--- a/tests/test_target_blender.py
+++ b/tests/test_target_blender.py
@@ -1,14 +1,8 @@
-import sys
-from pathlib import Path
-
 import pytest
 from hypothesis import given, strategies as st
 
 from ibkr_etf_rebalancer.target_blender import blend_targets
 from ibkr_etf_rebalancer.config import ModelsConfig
-
-# Ensure the package root is on the import path when running tests directly
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 # Strategies -----------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- remove individual sys.path manipulations from tests
- rely on `tests/conftest.py` to set package path

## Testing
- `pytest tests/test_portfolio_loader.py tests/test_config.py tests/test_target_blender.py tests/test_reporting.py`

------
https://chatgpt.com/codex/tasks/task_e_68b07d06553883208fc499a34235ee75