### PR TITLE
Clarify IBKR provider symbol override handling

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -185,9 +185,11 @@ ibkr_etf_rebalancer/
 **Goal:** Define an adapter interface; provide **FakeIB** (deterministic, in‑memory fills) and `LiveIB` stubs.  
 **Interface covers:**
 - connect/disconnect; contract resolution; quotes; account values (NetLiq, ExcessLiquidity, cash by currency); positions; place/cancel orders; await fills; pacing hooks.
+- contract resolution must apply `[symbol_overrides]` from `settings.ini`.
 **Tests:**
 - FakeIB lifecycle and fill simulation (configurable delays).
 - Pacing hook calls (no real sleeps in unit tests).
+- Verify a symbol listed in `[symbol_overrides]` resolves using the overridden contract or exchange.
 
 > Live tests are deferred; unit tests use FakeIB exclusively.
 


### PR DESCRIPTION
## Summary
- Ensure Phase 5 IBKR provider applies `[symbol_overrides]` when resolving contracts
- Add test guidance for verifying overridden symbol contracts/exchanges

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b07eec74dc8320b69708b35aa852c1