### PR TITLE
Plan: add post-trade reporting task

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -234,6 +234,12 @@ ibkr_etf_rebalancer/
 - Insufficient buying power → FakeIB account shortfall; tests assert exit.
 **Surfacing:** Map each to dedicated non-zero exit codes.
 
+### 7.4 `report_post` completion
+**Goal:** Finalize post-trade reporting. `report_post` writes CSV and Markdown outputs summarizing fills and residual drift.
+**Tests:**
+- Golden-file snapshots verifying fill summaries and residual drift columns.
+- Integration test confirms post-trade reports are generated in `reports/` and include target vs current vs residual drift (SRS AC8).
+
 ---
 
 ## 8) Phase 7 — End‑to‑End Scenarios


### PR DESCRIPTION
## Summary
- extend Phase 6 with a new `report_post` task to generate CSV and Markdown reports summarizing fills and residual drift
- outline tests using golden files and integration checks to satisfy SRS AC8

## Testing
- `pre-commit run --files plan.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b08263cee8832093a10ce987c93b85