### PR TITLE
Add max leverage validation to portfolio loader

### DIFF
--- a/tests/test_portfolio_loader.py
+++ b/tests/test_portfolio_loader.py
@@ -11,6 +11,7 @@ from ibkr_etf_rebalancer.portfolio_loader import load_portfolios, PortfolioError
             "basic",
             """portfolio,symbol,target_pct\nSMURF,VTI,40\nSMURF,VEA,30\nSMURF,BND,30\nBADASS,USMV,60\nBADASS,QUAL,40\nGLTR,IGV,50\nGLTR,XLV,50\n""",
             False,
+            1.0,
             {
                 "SMURF": {"VTI": 0.40, "VEA": 0.30, "BND": 0.30},
                 "BADASS": {"USMV": 0.60, "QUAL": 0.40},
@@ -21,6 +22,7 @@ from ibkr_etf_rebalancer.portfolio_loader import load_portfolios, PortfolioError
             "with_cash",
             """portfolio,symbol,target_pct\nSMURF,VTI,60\nSMURF,BND,40\nBADASS,SPY,100\nGLTR,GLD,100\nGLTR,GDX,50\nGLTR,CASH,-50\n""",
             True,
+            1.5,
             {
                 "SMURF": {"VTI": 0.60, "BND": 0.40},
                 "BADASS": {"SPY": 1.0},
@@ -31,15 +33,15 @@ from ibkr_etf_rebalancer.portfolio_loader import load_portfolios, PortfolioError
     ids=lambda p: p[0],
 )
 def valid_csv(tmp_path: Path, request):
-    name, csv_content, allow_margin, expected = request.param
+    name, csv_content, allow_margin, max_leverage, expected = request.param
     path = tmp_path / f"{name}.csv"
     path.write_text(csv_content)
-    return path, allow_margin, expected
+    return path, allow_margin, max_leverage, expected
 
 
 def test_load_valid_csv(valid_csv):
-    path, allow_margin, expected = valid_csv
-    result = load_portfolios(path, allow_margin=allow_margin)
+    path, allow_margin, max_leverage, expected = valid_csv
+    result = load_portfolios(path, allow_margin=allow_margin, max_leverage=max_leverage)
     assert result == expected
 
 
@@ -49,74 +51,129 @@ def test_load_valid_csv(valid_csv):
             "sum_not_100",
             """portfolio,symbol,target_pct\nSMURF,VTI,50\nSMURF,VEA,30\nSMURF,BND,30\n""",
             False,
+            2.0,
             "weights sum to 110.00%",
         ),
         (
             "cash_positive",
             """portfolio,symbol,target_pct\nSMURF,VTI,50\nSMURF,CASH,50\n""",
             True,
+            1.0,
             "CASH row must be negative",
         ),
         (
             "multi_cash",
             """portfolio,symbol,target_pct\nSMURF,VTI,100\nSMURF,CASH,-10\nSMURF,CASH,-10\n""",
             True,
+            1.0,
             "multiple CASH rows",
         ),
         (
             "cash_not_100",
             """portfolio,symbol,target_pct\nSMURF,VTI,90\nSMURF,CASH,-5\n""",
             True,
+            1.0,
             "asset weights 90.00% plus CASH -5.00% != 100%",
         ),
         (
             "cash_without_margin",
             """portfolio,symbol,target_pct\nSMURF,VTI,50\nSMURF,CASH,-50\n""",
             False,
+            1.0,
             "margin is disabled",
         ),
         (
             "unknown_portfolio",
             """portfolio,symbol,target_pct\nFOO,VTI,100\n""",
             False,
+            1.0,
             "Unknown portfolio",
         ),
         (
             "negative_pct",
             """portfolio,symbol,target_pct\nSMURF,VTI,-10\n""",
             False,
+            1.0,
             "negative target_pct",
         ),
         (
             "pct_gt_100",
             """portfolio,symbol,target_pct\nSMURF,VTI,150\n""",
             False,
+            1.0,
             "exceeds 100%",
         ),
         (
             "pct_nan",
             """portfolio,symbol,target_pct\nSMURF,VTI,NaN\n""",
             False,
+            1.0,
             "non-finite target_pct",
         ),
         (
             "pct_inf",
             """portfolio,symbol,target_pct\nSMURF,VTI,inf\n""",
             False,
+            1.0,
             "non-finite target_pct",
         ),
     ],
     ids=lambda p: p[0],
 )
 def invalid_csv(tmp_path: Path, request):
-    name, csv_content, allow_margin, message = request.param
+    name, csv_content, allow_margin, max_leverage, message = request.param
     path = tmp_path / f"{name}.csv"
     path.write_text(csv_content)
-    return path, allow_margin, message
+    return path, allow_margin, max_leverage, message
 
 
 def test_load_invalid_csv(invalid_csv):
-    path, allow_margin, message = invalid_csv
+    path, allow_margin, max_leverage, message = invalid_csv
     with pytest.raises(PortfolioError) as exc:
-        load_portfolios(path, allow_margin=allow_margin)
+        load_portfolios(path, allow_margin=allow_margin, max_leverage=max_leverage)
+    assert message in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "name,csv_content,max_leverage,expect",
+    [
+        (
+            "under_leverage",
+            """portfolio,symbol,target_pct\nSMURF,VTI,60\nSMURF,BND,60\nSMURF,CASH,-20\n""",
+            1.3,
+            {"SMURF": {"VTI": 0.60, "BND": 0.60, "CASH": -0.20}},
+        ),
+        (
+            "at_leverage",
+            """portfolio,symbol,target_pct\nSMURF,VTI,100\nSMURF,BND,50\nSMURF,CASH,-50\n""",
+            1.5,
+            {"SMURF": {"VTI": 1.0, "BND": 0.50, "CASH": -0.50}},
+        ),
+    ],
+    ids=["under_leverage", "at_leverage"],
+)
+def test_max_leverage_valid(tmp_path: Path, name, csv_content, max_leverage, expect):
+    path = tmp_path / f"{name}.csv"
+    path.write_text(csv_content)
+    result = load_portfolios(path, allow_margin=True, max_leverage=max_leverage)
+    assert result == expect
+
+
+@pytest.mark.parametrize(
+    "name,csv_content,max_leverage,message",
+    [
+        (
+            "exceed_leverage",
+            """portfolio,symbol,target_pct\nSMURF,VTI,100\nSMURF,BND,50\nSMURF,CASH,-50\n""",
+            1.4,
+            "asset weights 150.00% exceed max leverage 140.00%",
+        ),
+    ],
+    ids=["exceed_leverage"],
+)
+def test_max_leverage_invalid(tmp_path: Path, name, csv_content, max_leverage, message):
+    path = tmp_path / f"{name}.csv"
+    path.write_text(csv_content)
+    with pytest.raises(PortfolioError) as exc:
+        load_portfolios(path, allow_margin=True, max_leverage=max_leverage)
     assert message in str(exc.value)


### PR DESCRIPTION
## Summary
- support configurable `max_leverage` in `load_portfolios`
- validate portfolios against leverage limit and update docs
- add tests covering leverage limit successes and failures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0890bf03c832099791a3ab3fe017c