### PR TITLE
Validate trigger_mode input for rebalance engine

### DIFF
--- a/ibkr_etf_rebalancer/rebalance_engine.py
+++ b/ibkr_etf_rebalancer/rebalance_engine.py
@@ -120,6 +120,10 @@ def generate_orders(
         (negative).  Symbols for which no trade is required are omitted.
     """
 
+    valid_modes = {"per_holding", "total_drift"}
+    if trigger_mode not in valid_modes:
+        raise ValueError(f"Unsupported trigger_mode: {trigger_mode}")
+
     # ------------------------------------------------------------------
     # Determine raw desired order sizes in dollars
     orders_value: Dict[str, float] = {}

--- a/tests/test_rebalance_engine.py
+++ b/tests/test_rebalance_engine.py
@@ -246,3 +246,16 @@ def test_total_drift_trigger_mixed_sign(current, expected):
         portfolio_total_band_bps=100,
     )
     assert orders == expected
+
+
+def test_invalid_trigger_mode():
+    targets = {"AAA": 0.5}
+    current = {"AAA": 0.5}
+    with pytest.raises(ValueError):
+        generate_orders(
+            targets,
+            current,
+            PRICES,
+            EQUITY,
+            trigger_mode="invalid",
+        )


### PR DESCRIPTION
## Summary
- ensure `trigger_mode` only accepts `per_holding` and `total_drift`
- test that invalid trigger mode raises `ValueError`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b08a901c448320be549d513e2d3f63