### PR TITLE
Document IBKRQuoteProvider in Phase 5 plan

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -209,6 +209,13 @@ ibkr_etf_rebalancer/
 
 > Live tests are deferred; unit tests use FakeIB exclusively.
 
+### 6.2 `IBKRQuoteProvider`
+**Goal:** Implement a quote provider that uses `ibkr_provider` to fetch live bid/ask and FX quotes and plugs into `pricing.py`.
+**Tests:**
+- ETF and FX quotes retrieved via `ibkr_provider`.
+- Stale-quote handling and fallback chain exercised with real provider data.
+- Verification that `pricing.py` switches from `FakeQuoteProvider` to `IBKRQuoteProvider` when connected.
+
 ---
 
 ## 7) Phase 6 — Order Builder & Executor (Dry‑Run First)


### PR DESCRIPTION
## Summary
- Outline IBKRQuoteProvider under Phase 5 to supply live ETF and FX quotes via ibkr_provider
- Note tests for quote retrieval, staleness handling, and provider switching in pricing.py

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b08f3047208320beb990aade50f08e