### PR TITLE
Expose account snapshot helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,6 @@
 ## [Unreleased]
 - Placeholder for upcoming changes.
 
+## Phase 3
+- Support account snapshots via `AccountSnapshot` and `compute_account_state` exports. [SRS AC3]
+

--- a/ibkr_etf_rebalancer/__init__.py
+++ b/ibkr_etf_rebalancer/__init__.py
@@ -1,1 +1,5 @@
 """ibkr_etf_rebalancer package."""
+
+from .account_state import AccountSnapshot, compute_account_state
+
+__all__ = ["AccountSnapshot", "compute_account_state"]

--- a/plan.md
+++ b/plan.md
@@ -155,10 +155,16 @@ ibkr_etf_rebalancer/
 ## 4) Phase 3 — Account Snapshot Model (Offline)
 
 ### `account_state.py`
-**Goal:** Compute current weights from positions + prices; apply `cash_buffer_pct`; read per‑currency cash (USD/CAD).  
+**Goal:** Compute current weights from positions + prices; apply `cash_buffer_pct`; read per‑currency cash (USD/CAD).
 **Tests:**
 - Correct weight math with/without cash buffer.
 - USD and CAD balances kept separate and reported.
+
+**Usage:**
+```python
+from ibkr_etf_rebalancer import AccountSnapshot, compute_account_state
+snapshot = compute_account_state(positions, prices, cash)
+```
 
 ---
 

--- a/srs.md
+++ b/srs.md
@@ -181,7 +181,11 @@ ibkr_etf_rebalancer/
 └─ tests/                 # unit & scenario tests
 ```
 
-**Primary library:** `ib_async`.  
+Key snapshot helpers are re-exported for convenience; import
+``AccountSnapshot`` and ``compute_account_state`` directly from
+``ibkr_etf_rebalancer`` when performing offline analysis.
+
+**Primary library:** `ib_async`.
 **Python:** 3.10+ recommended.  
 **OS:** Windows 10+, macOS, or Linux (TWS/Gateway installed & running).
 

--- a/tests/test_account_state.py
+++ b/tests/test_account_state.py
@@ -2,7 +2,7 @@ import math
 import pytest
 from hypothesis import given, strategies as st
 
-from ibkr_etf_rebalancer.account_state import compute_account_state
+from ibkr_etf_rebalancer import AccountSnapshot, compute_account_state
 
 
 def test_weights_and_exposure_with_and_without_cash_buffer():
@@ -14,6 +14,7 @@ def test_weights_and_exposure_with_and_without_cash_buffer():
     buf = compute_account_state(positions, prices, cash, cash_buffer_pct=0.1)
 
     # Without buffer ---------------------------------------------------------
+    assert isinstance(no_buf, AccountSnapshot)
     assert pytest.approx(1_000 / 3_000, rel=1e-6) == no_buf.weights["SPY"]
     assert pytest.approx(1_000 / 3_000, rel=1e-6) == no_buf.weights["GLD"]
     assert pytest.approx(1_000 / 3_000, rel=1e-6) == no_buf.weights["CASH"]


### PR DESCRIPTION
## Summary
- export `AccountSnapshot` and `compute_account_state` at package root
- document account snapshot usage and changelog entry referencing SRS AC3
- adjust tests to import from top-level package

## Testing
- `ruff check . && black --check . && mypy . && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b098849bc08320a184388729d296fb