### PR TITLE
Document ignored portfolio columns

### DIFF
--- a/ibkr_etf_rebalancer/portfolio_loader.py
+++ b/ibkr_etf_rebalancer/portfolio_loader.py
@@ -33,6 +33,9 @@ def load_portfolios(
 ) -> Dict[str, Dict[str, float]]:
     """Read a portfolio CSV and return a mapping of model -> weights.
 
+    Columns ``note``, ``min_lot``, and ``exchange`` are silently ignored if
+    present.
+
     Parameters
     ----------
     csv_path:

--- a/tests/test_portfolio_loader.py
+++ b/tests/test_portfolio_loader.py
@@ -64,6 +64,7 @@ def test_load_ignores_extra_columns(extra_columns_csv):
     result = load_portfolios(path)
     assert result == expected
 
+
 @pytest.fixture(
     params=[
         (

--- a/tests/test_portfolio_loader.py
+++ b/tests/test_portfolio_loader.py
@@ -45,6 +45,25 @@ def test_load_valid_csv(valid_csv):
     assert result == expected
 
 
+@pytest.fixture
+def extra_columns_csv(tmp_path: Path):
+    """CSV containing optional columns that should be ignored."""
+    csv_content = (
+        "portfolio,symbol,target_pct,note,min_lot,exchange\n"
+        "SMURF,VTI,50,some note,10,NYSE\n"
+        "SMURF,VEA,50,other note,5,ARCA\n"
+    )
+    path = tmp_path / "extra.csv"
+    path.write_text(csv_content)
+    expected = {"SMURF": {"VTI": 0.50, "VEA": 0.50}}
+    return path, expected
+
+
+def test_load_ignores_extra_columns(extra_columns_csv):
+    path, expected = extra_columns_csv
+    result = load_portfolios(path)
+    assert result == expected
+
 @pytest.fixture(
     params=[
         (


### PR DESCRIPTION
## Summary
- Clarify that `note`, `min_lot`, and `exchange` columns are ignored by `load_portfolios`
- Add regression test ensuring optional columns do not affect weight parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0a2a41100832087a7abbb519930ed