### PR TITLE
Standardize cash_buffer_pct as percentage

### DIFF
--- a/ibkr_etf_rebalancer/account_state.py
+++ b/ibkr_etf_rebalancer/account_state.py
@@ -84,8 +84,8 @@ def compute_account_state(
     cash_balances:
         Mapping of currency code (e.g. ``"USD"``/``"CAD"``) to amount.
     cash_buffer_pct:
-        Fraction of the USD cash balance to exclude from exposure/weight
-        calculations.
+        Percentage of the USD cash balance to exclude from exposure/weight
+        calculations (e.g. ``5`` for ``5%``).
     """
 
     cash_by_currency = {ccy: float(amount) for ccy, amount in cash_balances.items()}
@@ -112,7 +112,7 @@ def compute_account_state(
         gross_pos_val += abs(value)
 
     total_equity = net_pos_val + usd_cash
-    effective_usd_cash = usd_cash * (1.0 - cash_buffer_pct)
+    effective_usd_cash = usd_cash * (1.0 - cash_buffer_pct / 100.0)
     effective_equity = net_pos_val + effective_usd_cash
     if effective_equity <= 0.0:
         raise ValueError("Account has zero equity")

--- a/ibkr_etf_rebalancer/config.py
+++ b/ibkr_etf_rebalancer/config.py
@@ -57,7 +57,10 @@ class RebalanceConfig(BaseModel):
         500, gt=0, description="Ignore trades smaller than this notional value"
     )
     cash_buffer_pct: float = Field(
-        1.0, ge=0, le=100, description="Hold back this percent of equity as cash"
+        1.0,
+        ge=0,
+        le=100,
+        description="Hold back this percentage of equity as cash (e.g. 5 for 5%)",
     )
     allow_fractional: bool = Field(
         False, description="Set true only if account supports fractional shares"

--- a/ibkr_etf_rebalancer/rebalance_engine.py
+++ b/ibkr_etf_rebalancer/rebalance_engine.py
@@ -98,8 +98,8 @@ def generate_orders(
         and ``CASH=-0.50``.
     cash_buffer_pct:
         Percentage of ``total_equity`` that must remain as cash after
-        rebalancing.  Buys are scaled down if necessary to leave this
-        cushion unspent.
+        rebalancing (e.g. ``5`` for ``5%``).  Buys are scaled down if
+        necessary to leave this cushion unspent.
     maintenance_buffer_pct:
         Additional headroom against the leverage cap expressed as a
         percentage of ``total_equity``.  Buys are scaled to keep gross

--- a/tests/test_account_state.py
+++ b/tests/test_account_state.py
@@ -11,7 +11,7 @@ def test_weights_and_exposure_with_and_without_cash_buffer():
     cash = {"USD": 1000.0, "CAD": 500.0}
 
     no_buf = compute_account_state(positions, prices, cash, cash_buffer_pct=0.0)
-    buf = compute_account_state(positions, prices, cash, cash_buffer_pct=0.1)
+    buf = compute_account_state(positions, prices, cash, cash_buffer_pct=10.0)
 
     # Without buffer ---------------------------------------------------------
     assert isinstance(no_buf, AccountSnapshot)
@@ -73,10 +73,10 @@ def test_weights_use_netliq_minus_cash_buffer_amount():
     prices = {"SPY": 100.0}
     cash = {"USD": 100.0}
 
-    snapshot = compute_account_state(positions, prices, cash, cash_buffer_pct=0.2)
+    snapshot = compute_account_state(positions, prices, cash, cash_buffer_pct=20.0)
 
     netliq = 1_000 + 100
-    buffer_amount = 100 * 0.2
+    buffer_amount = 100 * (20.0 / 100.0)
     denom = netliq - buffer_amount
 
     assert pytest.approx(1_000 / denom, rel=1e-6) == snapshot.weights["SPY"]

--- a/tests/test_rebalance_engine.py
+++ b/tests/test_rebalance_engine.py
@@ -86,7 +86,7 @@ def test_scaled_buy_dropped_below_min_order():
         bands=0.0,
         min_order=500.0,
         max_leverage=1.5,
-        cash_buffer_pct=0.8,
+        cash_buffer_pct=0.8,  # 0.8% buffer
     )
     assert orders == {}
 
@@ -198,7 +198,7 @@ def test_cash_buffer_limits_buys():
         bands=0.0,
         min_order=0.0,
         max_leverage=1.5,
-        cash_buffer_pct=5.0,
+        cash_buffer_pct=5.0,  # 5% buffer
         allow_fractional=False,
     )
     assert orders["BBB"] == -100


### PR DESCRIPTION
## Summary
- Treat `cash_buffer_pct` uniformly as a percentage across configuration, account state, and rebalancing logic
- Clarify tests and docs to use percent values (e.g., `5` for 5%) and document units in test cases

## Testing
- `pre-commit run --files ibkr_etf_rebalancer/account_state.py ibkr_etf_rebalancer/config.py ibkr_etf_rebalancer/rebalance_engine.py tests/test_account_state.py tests/test_rebalance_engine.py`
- `pytest tests/test_account_state.py tests/test_rebalance_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0ab2147ac8320b6e1ac8a241f40eb