### PR TITLE
docs: expand phase1 checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Placeholder for upcoming changes.
 - Document paper and live CLI examples in `workflow.md`.
 - Clarified Definition of Done in `plan.md` to include CHANGELOG entries and SRS acceptance-criteria references.
+- Expanded Phase 1 checklist with module-specific items, leverage test, and PR gate updates.
 
 ## Phase 3
 - Support account snapshots via `AccountSnapshot` and `compute_account_state` exports. [SRS AC3]

--- a/phase1_checklist.md
+++ b/phase1_checklist.md
@@ -8,6 +8,8 @@ Copy/paste into your PR or keep this file in `.github/` to guide reviews for **P
 - [ ] **Scope is Phase 1 only** (pure core; no broker/`ib_async`, no network I/O)
 - [ ] Only expected files changed (e.g., `portfolio_loader.py`, `tests/test_portfolio_loader.py`)
 - [ ] No new dependencies added to `requirements.txt`
+- [ ] PR description references relevant SRS acceptance criteria
+- [ ] `CHANGELOG.md` updated
 
 ## CI & local checks
 - [ ] CI is green (ruff, black, mypy, pytest)
@@ -22,9 +24,14 @@ Copy/paste into your PR or keep this file in `.github/` to guide reviews for **P
 ## Tests (table-driven & edge cases)
 - [ ] Valid CSVs load: per-portfolio sums = **100%** or **assets + CASH = 100%** (±0.01)
 - [ ] Exactly **one** optional `CASH` row per portfolio; **must be negative**
-- [ ] Descriptive errors for:  - [ ] Missing/unknown portfolio name  - [ ] Multiple `CASH` rows  - [ ] Non-numeric or out-of-range `target_pct`  - [ ] Sums not meeting the rule above
+- [ ] Descriptive errors for:
+  - [ ] Missing/unknown portfolio name
+  - [ ] Multiple `CASH` rows
+  - [ ] Non-numeric or out-of-range `target_pct`
+  - [ ] Sums not meeting the rule above
 - [ ] Fixtures cover **SMURF/BADASS/GLTR** with overlapping ETFs
 - [ ] Golden sample(s) included for a valid file and a few invalid files
+- [ ] Portfolios exceeding `[rebalance].max_leverage` are rejected
 
 ## Code quality
 - [ ] Clear dataclasses/types; no magic constants
@@ -43,6 +50,25 @@ Copy/paste into your PR or keep this file in `.github/` to guide reviews for **P
 - [ ] Normalization preserves signs (keep `CASH` negative internally)
 - [ ] Clear separation: parsing → validation → normalization
 - [ ] Unit tests assert **exact** error messages (or stable substrings) for bad inputs
+
+### Module-specific add-on: `config.py`
+- [ ] INI validation
+- [ ] Model weights sum to 100%
+- [ ] Margin knobs (e.g., `[rebalance].max_leverage`)
+
+### Module-specific add-on: `target_blender.py`
+- [ ] Overlap handling
+- [ ] Gross vs. net exposure
+
+### Module-specific add-on: `rebalance_engine.py`
+- [ ] Drift filtering
+- [ ] Min order
+- [ ] Leverage guard
+- [ ] Rounding rules
+
+### Module-specific add-on: `reporting.py`
+- [ ] Pre-trade report columns
+- [ ] Skeleton post-trade
 
 ### Reviewer quick commands
 ```bash


### PR DESCRIPTION
## Summary
- expand Phase 1 checklist with module-specific sections for config, target blending, rebalance engine, and reporting
- note that PR descriptions must cite SRS ACs and update the changelog
- add test checklist item ensuring portfolios beyond `[rebalance].max_leverage` are rejected (SRS AC11)

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0ae565a648320b278cf7db536a80b