### PR TITLE
Add Typer to mypy pre-commit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,4 @@ repos:
           - pytest               # so pytest imports resolve
           - hypothesis           # tests use hypothesis
           - freezegun            # tests import freezegun
+          - typer                # CLI utilities


### PR DESCRIPTION
## Summary
- include `typer` in mypy's pre-commit environment so CLI imports type-check

## Testing
- `pre-commit run --files ibkr_etf_rebalancer/app.py tests/test_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0b2ae81408320bce6604c8c95517e