### PR TITLE
docs: clarify error path requirements

### DIFF
--- a/workflow.md
+++ b/workflow.md
@@ -25,6 +25,7 @@ This guide summarizes how to use `srs.md` and `plan.md` with Codex to build the 
   - Benchmark runtime & quote concurrency; ensure <30 s, safe 4–6 quote fetches, and retry/backoff strategy
   - Add an entry to [`CHANGELOG.md`](CHANGELOG.md) under the latest release heading for each PR.
   - Structured logging follows SRS §5.10 (run-id, config echo, log level).
+  - Error paths surface clear messages and map to exit codes per SRS §5.11.
 
 ### Performance constraints
 - Full rebalance run should complete in under 30 s.


### PR DESCRIPTION
## Summary
- document error-path messaging and exit-code expectations from SRS §5.11

## Testing
- `make lint` *(fails: would reformat ibkr_etf_rebalancer/target_blender.py)*
- `make type`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b0b4be988c8320910b20cdf9bb7aa2