### PR TITLE
docs: note buffers in phase6 checklist

### DIFF
--- a/phase6_checklist.md
+++ b/phase6_checklist.md
@@ -27,6 +27,7 @@
 - [ ] Dry‑run prints pre‑trade report + order plan; paper mode places orders only on `FakeIB`
 - [ ] `price_source` fallback chain: `last` → `midpoint` → `bid/ask` → `snapshot`
 - [ ] Optional snapshot mode controlled by config
+- [ ] Applies `cash_buffer_pct` and `maintenance_buffer_pct` when sizing and sequencing orders
 
 ## `order_builder.py`
 - [ ] Pure mapping of plan → broker orders (no side effects)


### PR DESCRIPTION
## Summary
- document that Phase 6 order sizing and sequencing honor `cash_buffer_pct` and `maintenance_buffer_pct`

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat ibkr_etf_rebalancer/target_blender.py)*
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0b4ad4ef48320afc089c457db73a3