### PR TITLE
docs: enumerate missing fx config keys

### DIFF
--- a/phase4_checklist.md
+++ b/phase4_checklist.md
@@ -19,6 +19,7 @@
 
 ## Alignment with SRS `[fx]`
 - [ ] Respects config switches: `enabled`, `pair="USD.CAD"`, `fx_buffer_bps`, `min_fx_order_usd`, `max_fx_order_usd` (optional), `allow_market`, `limit_offset_pips` (or reuse spread-aware knobs)
+- [ ] Supports and tests config keys: `base_currency`, `funding_currencies`, `convert_mode`, `use_mid_for_planning`, `wait_for_fill_seconds`, `prefer_market_hours`
 - [ ] Treats **CAD cash as available** to fund **USD ETF buys**
 - [ ] Computes **USD shortfall** from planned USD‑denominated BUYs and current cash (after any sell proceeds if planner models that)
 - [ ] Applies **buffer**: shortfall × (1 + buffer_bps/10_000)


### PR DESCRIPTION
## Summary
- call out additional FX config keys and require tests for each in phase4 checklist

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat ibkr_etf_rebalancer/target_blender.py)*
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0b4a4509c83209b99ac149028cd07