### PR TITLE
Validate log_level with literals

### DIFF
--- a/ibkr_etf_rebalancer/config.py
+++ b/ibkr_etf_rebalancer/config.py
@@ -177,7 +177,21 @@ class IOConfig(BaseModel):
     """Input/output paths and options."""
 
     report_dir: str = Field("reports", description="Directory for generated reports")
-    log_level: str = Field("INFO", description="Logging verbosity")
+    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(
+        "INFO", description="Logging verbosity"
+    )
+
+    @field_validator("log_level", mode="before")
+    @classmethod
+    def _validate_log_level(cls, v: Any) -> str:
+        if isinstance(v, str):
+            level = v.strip().upper()
+            valid = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+            if level in valid:
+                return level
+        raise ValueError(
+            "log_level must be one of: DEBUG, INFO, WARNING, ERROR, CRITICAL"
+        )
 
 
 class AppConfig(BaseModel):

--- a/ibkr_etf_rebalancer/config.py
+++ b/ibkr_etf_rebalancer/config.py
@@ -189,9 +189,7 @@ class IOConfig(BaseModel):
             valid = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
             if level in valid:
                 return level
-        raise ValueError(
-            "log_level must be one of: DEBUG, INFO, WARNING, ERROR, CRITICAL"
-        )
+        raise ValueError("log_level must be one of: DEBUG, INFO, WARNING, ERROR, CRITICAL")
 
 
 class AppConfig(BaseModel):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -225,6 +225,25 @@ GLTR = 0.2
     assert cfg2.symbol_overrides == {}
 
 
+@pytest.mark.parametrize(
+    "level",
+    ["DEBUG", "info", "Warning", "error", "critical"],
+)
+def test_log_level_values(level: str) -> None:
+    data = valid_config_dict()
+    data["io"]["log_level"] = level
+    cfg = AppConfig(**data)
+    assert cfg.io.log_level == level.upper()
+
+
+@pytest.mark.parametrize("level", ["", "VERBOSE", "trace", "warn"])
+def test_log_level_invalid(level: str) -> None:
+    data = valid_config_dict()
+    data["io"]["log_level"] = level
+    with pytest.raises(ValidationError):
+        AppConfig(**data)
+
+
 def test_load_config_success(tmp_path: Path):
     ini = tmp_path / "config.ini"
     ini.write_text(


### PR DESCRIPTION
## Summary
- enforce IOConfig.log_level to use literal logging levels
- normalize log_level case and validate values
- add tests for valid/invalid log_level settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0bed395b88320a1d5f4fed335db0a