### PR TITLE
feat(cli): support global execution flags

### DIFF
--- a/ibkr_etf_rebalancer/app.py
+++ b/ibkr_etf_rebalancer/app.py
@@ -37,6 +37,7 @@ timestamped filename and echo a textual summary to standard output.
 from __future__ import annotations
 
 import csv
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
@@ -44,6 +45,8 @@ import typer
 
 from .account_state import compute_account_state
 from .config import load_config
+from .ibkr_provider import IBKRProviderOptions
+from .order_executor import OrderExecutionOptions
 from .portfolio_loader import load_portfolios
 from .reporting import generate_pre_trade_report
 from .target_blender import blend_targets
@@ -52,12 +55,39 @@ from .target_blender import blend_targets
 app = typer.Typer(help="Utilities for running pre-trade reports")
 
 
+@dataclass
+class CLIOptions:
+    """Global command line flags routed to downstream components."""
+
+    report_only: bool = False
+    dry_run: bool = False
+    paper: bool = False
+    live: bool = False
+    yes: bool = False
+
+
 @app.callback()
-def main() -> None:
+def main(
+    ctx: typer.Context,
+    report_only: bool = typer.Option(
+        False, "--report-only", help="Generate reports without placing orders"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Simulate actions without side effects"
+    ),
+    paper: bool = typer.Option(False, "--paper", help="Use the paper trading environment"),
+    live: bool = typer.Option(False, "--live", help="Use the live trading environment"),
+    yes: bool = typer.Option(False, "--yes", help="Assume yes for all confirmations"),
+) -> None:
     """IBKR ETF rebalancer command line utilities."""
-    # The callback keeps the application in multi-command mode even if only
-    # one subcommand is defined.
-    pass
+    # Store the options on the Typer context so subcommands can access them.
+    ctx.obj = CLIOptions(
+        report_only=report_only,
+        dry_run=dry_run,
+        paper=paper,
+        live=live,
+        yes=yes,
+    )
 
 
 def _parse_cash(values: Iterable[str]) -> dict[str, float]:
@@ -74,6 +104,7 @@ def _parse_cash(values: Iterable[str]) -> dict[str, float]:
 
 @app.command("pre-trade")
 def pre_trade(
+    ctx: typer.Context,
     config: Path = typer.Option(..., exists=True, readable=True, help="Path to INI config file"),
     portfolios: Path = typer.Option(
         ..., exists=True, readable=True, help="CSV describing model portfolios"
@@ -92,6 +123,15 @@ def pre_trade(
     ),
 ) -> None:
     """Generate a pre‑trade report using the supplied inputs."""
+
+    # Access global CLI options for future routing to downstream components.
+    options: CLIOptions = ctx.obj if isinstance(ctx.obj, CLIOptions) else CLIOptions()
+    _ibkr_opts = IBKRProviderOptions(
+        paper=options.paper, live=options.live, dry_run=options.dry_run
+    )
+    _exec_opts = OrderExecutionOptions(
+        report_only=options.report_only, dry_run=options.dry_run, yes=options.yes
+    )
 
     cfg = load_config(config)
 

--- a/ibkr_etf_rebalancer/ibkr_provider.py
+++ b/ibkr_etf_rebalancer/ibkr_provider.py
@@ -1,3 +1,24 @@
-"""Ibkr Provider module."""
+"""Interactive Brokers provider abstraction."""
 
-# TODO: implement ibkr provider
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class IBKRProviderOptions:
+    """Options for configuring the IBKR provider connection.
+
+    Parameters
+    ----------
+    paper:
+        Connect to the paper trading environment.
+    live:
+        Connect to a live trading environment.
+    dry_run:
+        Avoid performing any side effects on the provider.
+    """
+
+    paper: bool = False
+    live: bool = False
+    dry_run: bool = False

--- a/ibkr_etf_rebalancer/order_executor.py
+++ b/ibkr_etf_rebalancer/order_executor.py
@@ -1,3 +1,24 @@
-"""Order Executor module."""
+"""Order execution infrastructure."""
 
-# TODO: implement order executor
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class OrderExecutionOptions:
+    """Options controlling how orders are executed.
+
+    Parameters
+    ----------
+    report_only:
+        Generate reports without sending orders.
+    dry_run:
+        Simulate the execution flow without side effects.
+    yes:
+        Automatically answer affirmatively to confirmation prompts.
+    """
+
+    report_only: bool = False
+    dry_run: bool = False
+    yes: bool = False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import pytest
 from freezegun import freeze_time
 from typer.testing import CliRunner
 
@@ -70,3 +71,34 @@ def test_pre_trade_cli(tmp_path: Path) -> None:
     md = tmp_path / "pre_trade_report_20240101T120000.md"
     assert csv.exists()
     assert md.exists()
+
+
+@pytest.mark.parametrize(
+    "flag",
+    ["--report-only", "--dry-run", "--paper", "--live", "--yes"],
+)
+def test_pre_trade_cli_global_flags(tmp_path: Path, flag: str) -> None:
+    """Ensure top-level flags are accepted by the CLI."""
+
+    config, portfolios, positions = _write_basic_files(tmp_path)
+
+    with freeze_time("2024-01-01 12:00:00"):
+        result = runner.invoke(
+            app,
+            [
+                flag,
+                "pre-trade",
+                "--config",
+                str(config),
+                "--portfolios",
+                str(portfolios),
+                "--positions",
+                str(positions),
+                "--cash",
+                "USD=0",
+                "--output-dir",
+                str(tmp_path),
+            ],
+        )
+
+    assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- add global CLI flags `--report-only`, `--dry-run`, `--paper`, `--live`, and `--yes`
- route these flags to placeholder IBKR provider and order execution components
- test CLI with new global flags

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0bff8b7bc832091c151e4e12fad40