### PR TITLE
Clamp cross escalation to NBBO tick

### DIFF
--- a/ibkr_etf_rebalancer/limit_pricer.py
+++ b/ibkr_etf_rebalancer/limit_pricer.py
@@ -98,9 +98,14 @@ def price_limit_buy(
     if wide_or_stale:
         action = cfg.escalate_action
         if action == "cross":
-            # Use a price that is guaranteed to cross the spread
-            # by rounding the ask up to the next tick.
-            return _round_up_to_tick(ask, min_tick), "LMT"
+            # Start with a price that crosses the spread by rounding the ask
+            # up to the next tick.  When ``use_ask_bid_cap`` is enabled clamp
+            # the result so the final limit never exceeds the current ask
+            # after tick alignment.
+            price = _round_up_to_tick(ask, min_tick)
+            if cfg.use_ask_bid_cap:
+                price = min(price, _round_down_to_tick(ask, min_tick))
+            return price, "LMT"
         if action == "market":
             return None, "MKT"
         # action == "keep" simply keeps the capped price
@@ -143,9 +148,14 @@ def price_limit_sell(
     if wide_or_stale:
         action = cfg.escalate_action
         if action == "cross":
-            # Use a price that is guaranteed to cross the spread
-            # by rounding the bid down to the previous tick.
-            return _round_down_to_tick(bid, min_tick), "LMT"
+            # Start with a price that crosses the spread by rounding the bid
+            # down to the previous tick.  When ``use_ask_bid_cap`` is enabled
+            # clamp so the final limit never falls below the current bid after
+            # tick alignment.
+            price = _round_down_to_tick(bid, min_tick)
+            if cfg.use_ask_bid_cap:
+                price = max(price, _round_up_to_tick(bid, min_tick))
+            return price, "LMT"
         if action == "market":
             return None, "MKT"
 

--- a/tests/test_limit_pricer.py
+++ b/tests/test_limit_pricer.py
@@ -103,7 +103,7 @@ def test_wide_or_stale_escalation(bid, ask, delta, action, exp, t):
     else:
         assert p == pytest.approx(exp)
         if action == "cross":
-            assert p >= ask - 1e-9
+            assert p <= ask + 1e-9
 
 
 @pytest.mark.parametrize(
@@ -136,7 +136,7 @@ def test_sell_wide_or_stale_escalation(bid, ask, delta, action, exp, t):
     else:
         assert p == pytest.approx(exp)
         if action == "cross":
-            assert p <= bid + 1e-9
+            assert p >= bid - 1e-9
 
 
 @pytest.mark.parametrize(
@@ -147,42 +147,42 @@ def test_sell_wide_or_stale_escalation(bid, ask, delta, action, exp, t):
             99.9,
             100.013,
             0.005,
-            math.ceil(100.013 / 0.005) * 0.005,
+            math.floor(100.013 / 0.005) * 0.005,
         ),
         (
             price_limit_sell,
             99.987,
             100.1,
             0.005,
-            math.floor(99.987 / 0.005) * 0.005,
+            math.ceil(99.987 / 0.005) * 0.005,
         ),
         (
             price_limit_buy,
             99.9,
             100.025,
             0.01,
-            math.ceil(100.025 / 0.01) * 0.01,
+            math.floor(100.025 / 0.01) * 0.01,
         ),
         (
             price_limit_sell,
             99.975,
             100.1,
             0.01,
-            math.floor(99.975 / 0.01) * 0.01,
+            math.ceil(99.975 / 0.01) * 0.01,
         ),
     ],
 )
 def test_cross_rounds_non_tick_aligned(func, bid, ask, tick, exp):
-    """Cross escalation should tick align raw bid/ask prices."""
+    """Cross escalation tick aligns without breaching the NBBO."""
     now = datetime.now(timezone.utc)
     q = Quote(bid, ask, now)
     cfg = LimitsConfig(wide_spread_bps=0, escalate_action="cross")
     p, t = func(q, tick, cfg, now)
     assert t == "LMT" and p == pytest.approx(exp)
     if func is price_limit_buy:
-        assert p >= ask - 1e-9
+        assert p <= ask + 1e-9
     else:
-        assert p <= bid + 1e-9
+        assert p >= bid - 1e-9
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- ensure cross escalation honors ask/bid caps after tick rounding
- test cross escalation to verify buy prices never exceed ask and sell prices never dip below bid

## Testing
- `pytest tests/test_limit_pricer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0c31096188320a1bd10d6f88eda08