### PR TITLE
feat(config): add max FX order limit

### DIFF
--- a/ibkr_etf_rebalancer/config.py
+++ b/ibkr_etf_rebalancer/config.py
@@ -116,6 +116,9 @@ class FXConfig(BaseModel):
     )
     use_mid_for_planning: bool = Field(True, description="Size FX conversions using the mid price")
     min_fx_order_usd: float = Field(1000, gt=0, description="Skip conversions smaller than this")
+    max_fx_order_usd: float | None = Field(
+        None, gt=0, description="Upper bound on any single FX conversion"
+    )
     fx_buffer_bps: int = Field(20, ge=0, description="Buy a small extra cushion when converting")
     order_type: Literal["MKT", "LMT"] = Field(
         "MKT", description="Order type used for FX conversions"
@@ -250,6 +253,8 @@ def load_config(path: Path) -> AppConfig:
                 items["funding_currencies"] = [
                     s.strip() for s in items["funding_currencies"].split(",") if s.strip()
                 ]
+            if section == "fx" and "max_fx_order_usd" in items:
+                items["max_fx_order_usd"] = parser.getfloat(section, "max_fx_order_usd")
             if section == "symbol_overrides":
                 converted: dict[str, Any] = {}
                 for k, v in items.items():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -92,6 +92,41 @@ def test_invalid_fx_buffer():
         AppConfig(**data)
 
 
+def test_max_fx_order_usd_parsing(tmp_path: Path) -> None:
+    ini = tmp_path / "config.ini"
+    ini.write_text(
+        """
+[ibkr]
+account = DU123
+
+[models]
+SMURF = 0.5
+BADASS = 0.3
+GLTR = 0.2
+
+[rebalance]
+
+[fx]
+max_fx_order_usd = 5000
+
+[limits]
+
+[safety]
+
+[io]
+"""
+    )
+    cfg = load_config(ini)
+    assert cfg.fx.max_fx_order_usd == 5000
+
+
+def test_invalid_max_fx_order_usd():
+    data = valid_config_dict()
+    data["fx"]["max_fx_order_usd"] = -1
+    with pytest.raises(ValidationError):
+        AppConfig(**data)
+
+
 @pytest.mark.parametrize("price_source", ["last", "midpoint", "bidask"])
 def test_price_source_values(price_source: str) -> None:
     data = valid_config_dict()


### PR DESCRIPTION
## Summary
- add optional cap on single FX conversions via `max_fx_order_usd`
- parse `[fx]` `max_fx_order_usd` value from INI config
- test FX limit parsing and validation

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0c7934b048320b40630e8a66d6fd2