### PR TITLE
docs: document fx planning configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Placeholder for upcoming changes.
+- Added FX planning with `[fx]` configuration for offline CAD→USD conversions.
 - Document paper and live CLI examples in `workflow.md`.
 - Clarified Definition of Done in `plan.md` to include CHANGELOG entries and SRS acceptance-criteria references.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ python -m ibkr_etf_rebalancer.app pre-trade \
     --output-dir reports
 ```
 
+The configuration file can include an `[fx]` section to plan CAD→USD conversions:
+
+```ini
+[fx]
+enabled = true
+max_fx_order_usd = 5000
+limit_slippage_bps = 5
+```
+
+Phase 4 processes these conversions offline before submitting dependent ETF orders.
+
 The command reads a configuration file, model portfolio definitions and the
 current account positions before producing CSV and Markdown pre‑trade reports
 under the specified ``reports`` directory.

--- a/srs.md
+++ b/srs.md
@@ -115,6 +115,7 @@ funding_currencies = CAD       ; comma‑sep list; v1 supports CAD only
 convert_mode = just_in_time    ; just_in_time | always_top_up
 use_mid_for_planning = true    ; plan FX size using mid price
 min_fx_order_usd = 1000        ; skip tiny conversions
+max_fx_order_usd = 5000        ; cap single conversion size (optional)
 fx_buffer_bps = 20             ; buy a small extra cushion (0.20%)
 order_type = MKT               ; MKT | LMT
 limit_slippage_bps = 5         ; when order_type=LMT
@@ -149,7 +150,7 @@ log_level = INFO
 ```
 ### 3.3 `[pricing]` & `[fx]` configuration
 - `[pricing]` selects the quote source (`last`, `midpoint`, or `bidask`) and whether to fall back to snapshot data.
-- `[fx]` enables optional CAD→USD conversions, defining base/funding currencies, conversion timing, and order controls.
+- `[fx]` enables optional CAD→USD conversions, defining base/funding currencies, conversion timing, and order controls such as `max_fx_order_usd` and `limit_slippage_bps`.
 
 ### 3.4 `[limits]` — Spread‑aware limit pricing (default)
 - Default order type is **LMT** with a **spread‑aware** strategy.
@@ -513,6 +514,7 @@ funding_currencies=CAD
 convert_mode=just_in_time
 use_mid_for_planning=true
 min_fx_order_usd=1000
+max_fx_order_usd=5000
 fx_buffer_bps=20
 order_type=MKT
 limit_slippage_bps=5


### PR DESCRIPTION
## Summary
- document FX planning via `[fx]` config and offline CAD→USD conversions
- mention FX settings in README usage example
- reference `max_fx_order_usd` and `limit_slippage_bps` in SRS

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0d6a391b88320beb737d33122bb08