### PR TITLE
Respect pricing config when fetching FX rate

### DIFF
--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -83,7 +83,21 @@ def test_price_source_bidask_fallback_last() -> None:
     assert price == pytest.approx(99.5)
 
 
-def test_snapshot_fallback() -> None:
+def test_price_source_last_fallback_bidask_when_mid_missing() -> None:
+    now = datetime.now(timezone.utc)
+    provider = FakeQuoteProvider({"SYM": Quote(100.0, None, now, last=None)})
+    price = provider.get_price("SYM", "last")
+    assert price == pytest.approx(100.0)
+
+
+def test_price_source_last_fallback_ask_when_bid_missing() -> None:
+    now = datetime.now(timezone.utc)
+    provider = FakeQuoteProvider({"SYM": Quote(None, 101.0, now, last=None)})
+    price = provider.get_price("SYM", "last")
+    assert price == pytest.approx(101.0)
+
+
+def test_price_source_last_fallback_snapshot() -> None:
     now = datetime.now(timezone.utc)
     provider = FakeQuoteProvider(
         {"SYM": Quote(None, None, now, last=None)}, snapshots={"SYM": 98.7}

--- a/tests/test_rebalance_engine.py
+++ b/tests/test_rebalance_engine.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from ibkr_etf_rebalancer.config import FXConfig
+from ibkr_etf_rebalancer.config import FXConfig, PricingConfig
 from ibkr_etf_rebalancer.pricing import FakeQuoteProvider, Quote
 from ibkr_etf_rebalancer.rebalance_engine import generate_orders, plan_rebalance_with_fx
 
@@ -258,6 +258,7 @@ def test_fx_top_up_generates_plan_and_feasible_orders():
     fx_cfg = FXConfig(enabled=True)
     now = datetime.now(timezone.utc)
     provider = FakeQuoteProvider({"USD.CAD": Quote(1.25, 1.26, now)})
+    pricing_cfg = PricingConfig()
 
     orders, fx_plan = plan_rebalance_with_fx(
         targets,
@@ -266,6 +267,7 @@ def test_fx_top_up_generates_plan_and_feasible_orders():
         EQUITY,
         fx_cfg=fx_cfg,
         quote_provider=provider,
+        pricing_cfg=pricing_cfg,
         cad_cash=150_000.0,
         bands=0.0,
         min_order=0.0,
@@ -287,6 +289,7 @@ def test_sells_partially_fund_buys_reducing_fx():
     fx_cfg = FXConfig(enabled=True)
     now = datetime.now(timezone.utc)
     provider = FakeQuoteProvider({"USD.CAD": Quote(1.25, 1.26, now)})
+    pricing_cfg = PricingConfig()
 
     orders, fx_plan = plan_rebalance_with_fx(
         targets,
@@ -295,6 +298,7 @@ def test_sells_partially_fund_buys_reducing_fx():
         EQUITY,
         fx_cfg=fx_cfg,
         quote_provider=provider,
+        pricing_cfg=pricing_cfg,
         cad_cash=10_000.0,
         bands=0.0,
         min_order=0.0,


### PR DESCRIPTION
## Summary
- Retrieve USD.CAD rate via `quote_provider.get_price` and honour `PricingConfig` options
- Exercise complete price-source fallback chain in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0dde71810832090cff21883bed3bc