### PR TITLE
Validate funding currency and generalize FX pair

### DIFF
--- a/ibkr_etf_rebalancer/rebalance_engine.py
+++ b/ibkr_etf_rebalancer/rebalance_engine.py
@@ -240,16 +240,23 @@ def plan_rebalance_with_fx(
     fx_cfg: FXConfig,
     quote_provider: QuoteProvider,
     pricing_cfg: PricingConfig,
+    funding_currency: str = "CAD",
     **kwargs: Any,
 ) -> tuple[Dict[str, float], FxPlan]:
     """Plan equity trades and any required FX conversion."""
 
-    cad_cash = float(kwargs.pop("cad_cash", 0.0))
+    funding_cash = float(
+        kwargs.pop("funding_cash", kwargs.pop("cad_cash", 0.0))
+    )
+    if funding_currency not in fx_cfg.funding_currencies:
+        raise ValueError(f"unsupported funding currency: {funding_currency}")
     usd_cash = current.get("CASH", 0.0) * total_equity
 
-    # First pass: assume CAD cash is converted to size desired equity orders
+    pair = f"{fx_cfg.base_currency}.{funding_currency}"
+
+    # First pass: assume funding cash is converted to size desired equity orders
     planning_current = dict(current)
-    planning_current["CASH"] = (usd_cash + cad_cash) / total_equity
+    planning_current["CASH"] = (usd_cash + funding_cash) / total_equity
     orders = generate_orders(targets, planning_current, prices, total_equity, **kwargs)
 
     usd_buy_notional = sum(
@@ -262,7 +269,7 @@ def plan_rebalance_with_fx(
 
     fx_plan = FxPlan(
         need_fx=False,
-        pair=f"{fx_cfg.base_currency}.CAD",
+        pair=pair,
         side="BUY",
         usd_notional=0.0,
         est_rate=0.0,
@@ -279,7 +286,7 @@ def plan_rebalance_with_fx(
     )
     if need_fx:
         rate = quote_provider.get_price(
-            "USD.CAD",
+            pair,
             pricing_cfg.price_source,
             fallback_to_snapshot=pricing_cfg.fallback_to_snapshot,
         )
@@ -291,9 +298,10 @@ def plan_rebalance_with_fx(
         fx_plan = plan_fx_if_needed(
             usd_needed=usd_needed,
             usd_cash=usd_cash_after_sells,
-            cad_cash=cad_cash,
+            funding_cash=funding_cash,
             fx_quote=fx_quote,
             cfg=fx_cfg,
+            funding_currency=funding_currency,
         )
 
     final_cash = usd_cash + fx_plan.usd_notional

--- a/tests/test_fx_engine.py
+++ b/tests/test_fx_engine.py
@@ -23,7 +23,7 @@ def test_cad_only_cash_needs_fx(fresh_quote: Quote, fx_cfg: FXConfig) -> None:
     plan = plan_fx_if_needed(
         usd_needed=5_000,
         usd_cash=0,
-        cad_cash=20_000,
+        funding_cash=20_000,
         fx_quote=fresh_quote,
         cfg=fx_cfg,
     )
@@ -37,7 +37,7 @@ def test_shortfall_below_min_skips_fx(fresh_quote: Quote, fx_cfg: FXConfig) -> N
     plan = plan_fx_if_needed(
         usd_needed=500,
         usd_cash=0,
-        cad_cash=20_000,
+        funding_cash=20_000,
         fx_quote=fresh_quote,
         cfg=fx_cfg,
     )
@@ -50,7 +50,7 @@ def test_buffer_applied_to_notional(fresh_quote: Quote, fx_cfg: FXConfig) -> Non
     plan = plan_fx_if_needed(
         usd_needed=shortfall,
         usd_cash=0,
-        cad_cash=20_000,
+        funding_cash=20_000,
         fx_quote=fresh_quote,
         cfg=fx_cfg,
     )
@@ -62,7 +62,7 @@ def test_missing_fx_quote_skips_plan(fx_cfg: FXConfig) -> None:
     plan = plan_fx_if_needed(
         usd_needed=1_000,
         usd_cash=0,
-        cad_cash=5_000,
+        funding_cash=5_000,
         fx_quote=None,
         cfg=fx_cfg,
     )
@@ -76,7 +76,7 @@ def test_stale_fx_quote_skips_plan(fresh_quote: Quote, fx_cfg: FXConfig) -> None
     plan = plan_fx_if_needed(
         usd_needed=1_000,
         usd_cash=0,
-        cad_cash=5_000,
+        funding_cash=5_000,
         fx_quote=stale,
         cfg=fx_cfg,
     )
@@ -89,7 +89,7 @@ def test_market_rounding(fx_cfg: FXConfig) -> None:
     plan = plan_fx_if_needed(
         usd_needed=1_234.56,
         usd_cash=0,
-        cad_cash=10_000,
+        funding_cash=10_000,
         fx_quote=quote,
         cfg=fx_cfg,
     )
@@ -105,7 +105,7 @@ def test_limit_order_rounding(fx_cfg: FXConfig) -> None:
     plan = plan_fx_if_needed(
         usd_needed=1_000,
         usd_cash=0,
-        cad_cash=10_000,
+        funding_cash=10_000,
         fx_quote=quote,
         cfg=cfg,
     )
@@ -118,7 +118,7 @@ def test_max_order_cap_applied(fresh_quote: Quote) -> None:
     plan = plan_fx_if_needed(
         usd_needed=10_000,
         usd_cash=100,
-        cad_cash=20_000,
+        funding_cash=20_000,
         fx_quote=fresh_quote,
         cfg=cfg,
     )
@@ -130,7 +130,7 @@ def test_no_usd_shortfall_skips_plan(fresh_quote: Quote, fx_cfg: FXConfig) -> No
     plan = plan_fx_if_needed(
         usd_needed=1_000,
         usd_cash=1_200,
-        cad_cash=5_000,
+        funding_cash=5_000,
         fx_quote=fresh_quote,
         cfg=fx_cfg,
     )
@@ -142,7 +142,7 @@ def test_no_cad_cash_skips_plan(fresh_quote: Quote, fx_cfg: FXConfig) -> None:
     plan = plan_fx_if_needed(
         usd_needed=1_000,
         usd_cash=0,
-        cad_cash=0,
+        funding_cash=0,
         fx_quote=fresh_quote,
         cfg=fx_cfg,
     )
@@ -155,7 +155,7 @@ def test_use_ask_when_mid_disabled(fresh_quote: Quote, fx_cfg: FXConfig) -> None
     plan = plan_fx_if_needed(
         usd_needed=1_000,
         usd_cash=0,
-        cad_cash=5_000,
+        funding_cash=5_000,
         fx_quote=fresh_quote,
         cfg=cfg,
     )
@@ -202,7 +202,7 @@ def test_always_top_up_converts(fresh_quote: Quote) -> None:
         fx_cfg=cfg,
         quote_provider=provider,
         pricing_cfg=pricing_cfg,
-        cad_cash=20_000,
+        funding_cash=20_000,
     )
     assert plan.need_fx is True
     assert plan.usd_notional >= cfg.min_fx_order_usd
@@ -214,7 +214,7 @@ def test_prefer_market_hours_blocks_off_hours(fresh_quote: Quote, fx_cfg: FXConf
     plan = plan_fx_if_needed(
         usd_needed=5_000,
         usd_cash=0,
-        cad_cash=20_000,
+        funding_cash=20_000,
         fx_quote=fresh_quote,
         cfg=cfg,
         now=saturday,

--- a/tests/test_rebalance_engine.py
+++ b/tests/test_rebalance_engine.py
@@ -268,7 +268,7 @@ def test_fx_top_up_generates_plan_and_feasible_orders():
         fx_cfg=fx_cfg,
         quote_provider=provider,
         pricing_cfg=pricing_cfg,
-        cad_cash=150_000.0,
+        funding_cash=150_000.0,
         bands=0.0,
         min_order=0.0,
         max_leverage=1.5,
@@ -299,7 +299,7 @@ def test_sells_partially_fund_buys_reducing_fx():
         fx_cfg=fx_cfg,
         quote_provider=provider,
         pricing_cfg=pricing_cfg,
-        cad_cash=10_000.0,
+        funding_cash=10_000.0,
         bands=0.0,
         min_order=0.0,
         max_leverage=1.5,
@@ -310,6 +310,28 @@ def test_sells_partially_fund_buys_reducing_fx():
     assert fx_plan.usd_notional == pytest.approx(expected_fx)
     assert orders["AAA"] == pytest.approx(-50)
     assert orders["BBB"] == pytest.approx(150)
+
+
+def test_unsupported_funding_currency_rejected():
+    targets = {"AAA": 0.5, "BBB": 0.5}
+    current = {"AAA": 0.0, "BBB": 0.0, "CASH": 0.0}
+    prices = {"AAA": 100.0, "BBB": 100.0}
+    fx_cfg = FXConfig(enabled=True)
+    pricing_cfg = PricingConfig()
+    provider = FakeQuoteProvider({})
+
+    with pytest.raises(ValueError):
+        plan_rebalance_with_fx(
+            targets,
+            current,
+            prices,
+            EQUITY,
+            fx_cfg=fx_cfg,
+            quote_provider=provider,
+            pricing_cfg=pricing_cfg,
+            funding_currency="EUR",
+            funding_cash=10_000.0,
+        )
 
 
 def test_invalid_trigger_mode():


### PR DESCRIPTION
## Summary
- validate requested funding currency before planning FX
- generalize FX pair construction and funding cash handling
- test unsupported funding currency scenario

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0df10d1fc83208aee8c9703ddd391