### PR TITLE
Preserve FX quotes for spread-aware planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Document paper and live CLI examples in `workflow.md`.
 - Clarified Definition of Done in `plan.md` to include CHANGELOG entries and SRS acceptance-criteria references.
 
+- Preserve FX bid/ask by using `get_quote` and pass full quotes to the FX planner; tests ensure limit prices respect spreads.
+
 - Expanded Phase 1 checklist with module-specific items, leverage test, and PR gate updates.
 
 - Added Phase 0 review checklist.

--- a/ibkr_etf_rebalancer/rebalance_engine.py
+++ b/ibkr_etf_rebalancer/rebalance_engine.py
@@ -38,7 +38,6 @@ other trades and the leverage constraints.
 from __future__ import annotations
 
 import math
-from datetime import datetime, timezone
 from typing import Any, Dict, Mapping
 
 from .config import FXConfig, PricingConfig
@@ -283,13 +282,7 @@ def plan_rebalance_with_fx(
         usd_buy_notional > usd_cash_after_sells or fx_cfg.convert_mode == "always_top_up"
     )
     if need_fx:
-        rate = quote_provider.get_price(
-            pair,
-            pricing_cfg.price_source,
-            fallback_to_snapshot=pricing_cfg.fallback_to_snapshot,
-        )
-        now = datetime.now(timezone.utc)
-        fx_quote = Quote(bid=rate, ask=rate, ts=now, last=rate)
+        fx_quote = quote_provider.get_quote(pair)
         usd_needed = usd_buy_notional
         if fx_cfg.convert_mode == "always_top_up":
             usd_needed = max(usd_buy_notional, fx_cfg.min_fx_order_usd)

--- a/tests/test_fx_engine.py
+++ b/tests/test_fx_engine.py
@@ -110,6 +110,7 @@ def test_limit_order_rounding(fx_cfg: FXConfig) -> None:
         cfg=cfg,
     )
     assert plan.limit_price == pytest.approx(1.2353)
+    assert plan.limit_price >= quote.ask
     assert plan.order_type == "LMT"
 
 


### PR DESCRIPTION
## Summary
- Fetch FX quotes with `get_quote` and feed full quote into `plan_fx_if_needed`
- Assert FX limit prices stay outside the bid/ask spread

## Testing
- `pytest tests/test_fx_engine.py tests/test_rebalance_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_68b0e165b8e483208e7096e3ee62f3e3