### PR TITLE
Ensure quote ask non-null in limit order test

### DIFF
--- a/tests/test_fx_engine.py
+++ b/tests/test_fx_engine.py
@@ -110,6 +110,8 @@ def test_limit_order_rounding(fx_cfg: FXConfig) -> None:
         cfg=cfg,
     )
     assert plan.limit_price == pytest.approx(1.2353)
+    assert plan.limit_price is not None
+    assert quote.ask is not None
     assert plan.limit_price >= quote.ask
     assert plan.order_type == "LMT"
 


### PR DESCRIPTION
## Summary
- guard comparisons against optional limit and ask prices in FX engine tests

## Testing
- `ruff check tests/test_fx_engine.py`
- `black --check tests/test_fx_engine.py`
- `python -m mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0e45934f48320917a43eb0301c776