### PR TITLE
Cap FX conversions by available funding cash

### DIFF
--- a/tests/test_rebalance_engine.py
+++ b/tests/test_rebalance_engine.py
@@ -305,7 +305,8 @@ def test_sells_partially_fund_buys_reducing_fx():
         max_leverage=1.5,
     )
 
-    expected_fx = 10_000 * (1 + fx_cfg.fx_buffer_bps / 10_000)
+    est_rate = round(provider.get_quote("USD.CAD").mid(), 4)
+    expected_fx = round(10_000 / est_rate, 2)
     assert fx_plan.need_fx is True
     assert fx_plan.usd_notional == pytest.approx(expected_fx)
     assert orders["AAA"] == pytest.approx(-50)


### PR DESCRIPTION
## Summary
- cap USD FX notional using available CAD based on quote rate
- handle insufficient CAD funds and adjust rebalance test
- add tests for FX cap and insufficient funding cash cases

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0e5c60bc4832082662bf34fc440d2