### PR TITLE
Make FX quote staleness configurable

### DIFF
--- a/ibkr_etf_rebalancer/config.py
+++ b/ibkr_etf_rebalancer/config.py
@@ -124,6 +124,7 @@ class FXConfig(BaseModel):
         "MKT", description="Order type used for FX conversions"
     )
     limit_slippage_bps: int = Field(5, ge=0, description="Slippage when order_type='LMT'")
+    stale_quote_seconds: int = Field(10, ge=0, description="Quote age before considered stale")
     route: str = Field("IDEALPRO", description="IBKR FX venue")
     wait_for_fill_seconds: int = Field(
         5, ge=0, description="Pause before placing dependent ETF orders"

--- a/ibkr_etf_rebalancer/fx_engine.py
+++ b/ibkr_etf_rebalancer/fx_engine.py
@@ -198,7 +198,7 @@ def plan_fx_if_needed(
             reason="no FX quote",
         )
 
-    if pricing.is_stale(fx_quote, now, stale_quote_seconds=10):
+    if pricing.is_stale(fx_quote, now, stale_quote_seconds=cfg.stale_quote_seconds):
         return FxPlan(
             need_fx=False,
             pair=pair,


### PR DESCRIPTION
## Summary
- allow configuring FX quote staleness via `stale_quote_seconds`
- check FX quote age against configuration in `plan_fx_if_needed`
- test FX planning when quotes exceed or meet the staleness threshold

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0e72792f483208a68e34823b89426