### PR TITLE
Add configurable FX pricing with snapshot fallback

### DIFF
--- a/tests/test_rebalance_engine.py
+++ b/tests/test_rebalance_engine.py
@@ -371,9 +371,7 @@ def test_fx_snapshot_fallback():
     fx_cfg = FXConfig(enabled=True)
     pricing_cfg = PricingConfig(fallback_to_snapshot=True)
     now = datetime.now(timezone.utc)
-    provider = FakeQuoteProvider(
-        {"USD.CAD": Quote(None, None, now)}, snapshots={"USD.CAD": 1.2}
-    )
+    provider = FakeQuoteProvider({"USD.CAD": Quote(None, None, now)}, snapshots={"USD.CAD": 1.2})
 
     _, fx_plan = plan_rebalance_with_fx(
         targets,


### PR DESCRIPTION
## Summary
- support explicit FX price retrieval using configurable price sources with snapshot fallback
- allow FX planning with provided price when quotes are missing
- cover FX snapshot fallback and price-source precedence with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0e9f4d5d08320b2cb5155498c27ea