### PR TITLE
Normalize funding currency for FX planning

### DIFF
--- a/ibkr_etf_rebalancer/fx_engine.py
+++ b/ibkr_etf_rebalancer/fx_engine.py
@@ -116,6 +116,7 @@ def plan_fx_if_needed(
         Currency used to fund USD purchases. Defaults to ``"CAD"``.
     """
 
+    funding_currency = funding_currency.upper()
     pair = f"{cfg.base_currency}.{funding_currency}"
     side: Literal["BUY", "SELL"] = "BUY"
     now = now or datetime.now(timezone.utc)

--- a/ibkr_etf_rebalancer/rebalance_engine.py
+++ b/ibkr_etf_rebalancer/rebalance_engine.py
@@ -245,7 +245,9 @@ def plan_rebalance_with_fx(
     """Plan equity trades and any required FX conversion."""
 
     funding_cash = float(kwargs.pop("funding_cash", kwargs.pop("cad_cash", 0.0)))
-    if funding_currency not in fx_cfg.funding_currencies:
+    funding_currency = funding_currency.upper()
+    allowed_funding = {c.upper() for c in fx_cfg.funding_currencies}
+    if funding_currency not in allowed_funding:
         raise ValueError(f"unsupported funding currency: {funding_currency}")
     usd_cash = current.get("CASH", 0.0) * total_equity
 

--- a/tests/test_rebalance_engine.py
+++ b/tests/test_rebalance_engine.py
@@ -364,6 +364,34 @@ def test_unsupported_funding_currency_rejected():
         )
 
 
+def test_mixed_case_funding_currency_accepted():
+    targets = {"AAA": 0.5, "BBB": 0.5, "CASH": 0.0}
+    current = {"AAA": 0.0, "BBB": 0.0, "CASH": 0.0}
+    prices = {"AAA": 100.0, "BBB": 100.0}
+    fx_cfg = FXConfig(enabled=True)
+    pricing_cfg = PricingConfig()
+    now = datetime.now(timezone.utc)
+    provider = FakeQuoteProvider({"USD.CAD": Quote(1.25, 1.26, now)})
+
+    _, fx_plan = plan_rebalance_with_fx(
+        targets,
+        current,
+        prices,
+        EQUITY,
+        fx_cfg=fx_cfg,
+        quote_provider=provider,
+        pricing_cfg=pricing_cfg,
+        funding_currency="cAd",
+        funding_cash=150_000.0,
+        bands=0.0,
+        min_order=0.0,
+        max_leverage=1.5,
+    )
+
+    assert fx_plan.pair == "USD.CAD"
+    assert fx_plan.need_fx is True
+
+
 def test_fx_snapshot_fallback():
     targets = {"AAA": 0.5, "BBB": 0.5, "CASH": 0.0}
     current = {"AAA": 0.0, "BBB": 0.0, "CASH": 0.0}


### PR DESCRIPTION
## Summary
- Uppercase funding currency before validation and pair construction
- Ensure FxPlan pairs use normalized funding currency
- Test that mixed-case funding currency values are accepted

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0ebead204832091cb219b97d8378a