### PR TITLE
Remove unused type ignore in provider import

### DIFF
--- a/ibkr_etf_rebalancer/ibkr_provider.py
+++ b/ibkr_etf_rebalancer/ibkr_provider.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone, timedelta
 from enum import Enum
 from typing import Callable, Mapping, Protocol, Sequence, runtime_checkable
 
-from ib_async import IB, Contract as IBContract, Order as IBOrder  # type: ignore
+from ib_async import IB, Contract as IBContract, Order as IBOrder
 
 from . import pricing
 


### PR DESCRIPTION
## Summary
- remove outdated `type: ignore` on `ib_async` import

## Testing
- `make lint`
- `make type`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68b0f98e5e3883209292fd5a6d9f2356