### PR TITLE
Implement IBKRQuoteProvider for live pricing with IBKR

### DIFF
--- a/ibkr_etf_rebalancer/pricing.py
+++ b/ibkr_etf_rebalancer/pricing.py
@@ -8,8 +8,8 @@ required for the algorithms in :mod:`limit_pricer` and its tests.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
-from typing import Literal, Protocol
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Literal, Mapping, Protocol
 
 
 __all__ = [
@@ -17,7 +17,11 @@ __all__ = [
     "is_stale",
     "QuoteProvider",
     "FakeQuoteProvider",
+    "IBKRQuoteProvider",
 ]
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from .ibkr_provider import Contract, IBKRProvider
 
 
 @dataclass
@@ -110,6 +114,122 @@ class FakeQuoteProvider:
                     return quote.bid
                 if quote.ask is not None:
                     return quote.ask
+
+        if fallback_to_snapshot and symbol in self._snapshots:
+            return self._snapshots[symbol]
+
+        raise ValueError(f"No price available for {symbol}")
+
+
+class IBKRQuoteProvider:
+    """Quote provider backed by an :class:`IBKRProvider` instance.
+
+    The provider fetches quotes through an ``IBKRProvider`` implementation,
+    handling contract resolution for both equity symbols and foreign exchange
+    pairs (e.g. ``"USD.CAD"``).  It mirrors the behaviour of
+    :class:`FakeQuoteProvider` but sources its data from the Interactive Brokers
+    adapter.
+    """
+
+    def __init__(
+        self,
+        ibkr: "IBKRProvider",
+        *,
+        stale_quote_seconds: int = 10,
+        snapshots: Mapping[str, float] | None = None,
+    ) -> None:
+        self._ib = ibkr
+        self._stale = stale_quote_seconds
+        self._snapshots = dict(snapshots or {})
+
+    # ------------------------------------------------------------------
+    def _resolve(self, symbol: str) -> "Contract":
+        """Return a resolved contract for *symbol*.
+
+        Equity symbols resolve as ``STK`` contracts.  Symbols containing a dot
+        are treated as FX pairs in ``BASE.QUOTE`` form and resolved as ``CASH``
+        contracts routed through ``IDEALPRO``.
+        """
+
+        from .ibkr_provider import Contract, ResolutionError
+
+        if "." in symbol:
+            base, quote = symbol.split(".", 1)
+            contract = Contract(
+                symbol=base,
+                sec_type="CASH",
+                currency=quote,
+                exchange="IDEALPRO",
+            )
+            try:
+                return self._ib.resolve_contract(contract)
+            except ResolutionError:
+                contract = Contract(
+                    symbol=symbol,
+                    sec_type="CASH",
+                    currency=quote,
+                    exchange="IDEALPRO",
+                )
+                return self._ib.resolve_contract(contract)
+
+        contract = Contract(symbol=symbol, sec_type="STK")
+        return self._ib.resolve_contract(contract)
+
+    # ------------------------------------------------------------------
+    def get_quote(self, symbol: str) -> Quote:
+        """Return a :class:`Quote` for *symbol*.
+
+        The symbol is resolved to a contract via the underlying ``IBKRProvider``
+        before retrieving the latest quote.
+        """
+
+        from .ibkr_provider import Quote as IBQuote
+
+        contract = self._resolve(symbol)
+        ib_quote: IBQuote | Quote = self._ib.get_quote(contract)
+        if isinstance(ib_quote, Quote):
+            return ib_quote
+        ts = ib_quote.timestamp or datetime.now(timezone.utc)
+        return Quote(ib_quote.bid, ib_quote.ask, ts, last=ib_quote.last)
+
+    # ------------------------------------------------------------------
+    def get_price(
+        self,
+        symbol: str,
+        price_source: Literal["last", "midpoint", "bidask"],
+        fallback_to_snapshot: bool = False,
+    ) -> float:
+        """Return a price for *symbol* using *price_source* with fallbacks.
+
+        Prices are rejected if the underlying quote is older than
+        ``stale_quote_seconds``.  In such cases, or when the desired price source
+        is unavailable, the method falls back through ``last``, ``midpoint`` and
+        ``bidask`` before optionally returning a snapshot price.
+        """
+
+        quote = self.get_quote(symbol)
+        now = datetime.now(timezone.utc)
+
+        chain = ["last", "midpoint", "bidask"]
+        if price_source not in chain:
+            raise ValueError("price_source must be 'last', 'midpoint', or 'bidask'")
+        idx = chain.index(price_source)
+        ordered = chain[idx:] + chain[:idx]
+
+        if not is_stale(quote, now, self._stale):
+            for src in ordered:
+                if src == "last" and quote.last is not None:
+                    return quote.last
+                if src == "midpoint":
+                    try:
+                        return quote.mid()
+                    except ValueError:
+                        pass
+                if src == "bidask":
+                    if quote.bid is not None:
+                        return quote.bid
+                    if quote.ask is not None:
+                        return quote.ask
 
         if fallback_to_snapshot and symbol in self._snapshots:
             return self._snapshots[symbol]

--- a/tests/test_ibkr_quote_provider.py
+++ b/tests/test_ibkr_quote_provider.py
@@ -1,0 +1,56 @@
+import pytest
+from datetime import datetime, timedelta, timezone
+from typing import cast
+
+from ibkr_etf_rebalancer.pricing import IBKRQuoteProvider, Quote
+from ibkr_etf_rebalancer.ibkr_provider import Contract, FakeIB, IBKRProvider
+
+
+@pytest.fixture
+def ibkr_quote_provider() -> IBKRQuoteProvider:
+    now = datetime.now(timezone.utc)
+    contracts = {
+        "AAA": Contract(symbol="AAA"),
+        "USD": Contract(symbol="USD", sec_type="CASH", currency="CAD", exchange="IDEALPRO"),
+    }
+    quotes = {
+        "AAA": Quote(bid=100.0, ask=101.0, ts=now, last=100.5),
+        "USD": Quote(bid=1.25, ask=1.26, ts=now, last=1.255),
+    }
+    ib = FakeIB(contracts=contracts, quotes=quotes)
+    return IBKRQuoteProvider(cast(IBKRProvider, ib))
+
+
+def test_get_quote_equity(ibkr_quote_provider: IBKRQuoteProvider) -> None:
+    quote = ibkr_quote_provider.get_quote("AAA")
+    assert quote.bid == pytest.approx(100.0)
+    assert quote.ask == pytest.approx(101.0)
+
+
+def test_get_quote_fx_pair(ibkr_quote_provider: IBKRQuoteProvider) -> None:
+    quote = ibkr_quote_provider.get_quote("USD.CAD")
+    assert quote.mid() == pytest.approx((1.25 + 1.26) / 2)
+
+
+def test_price_fallback_chain() -> None:
+    now = datetime.now(timezone.utc)
+    contracts = {"SYM": Contract(symbol="SYM")}
+    quotes = {"SYM": Quote(bid=100.0, ask=None, ts=now, last=None)}
+    ib = FakeIB(contracts=contracts, quotes=quotes)
+    provider = IBKRQuoteProvider(cast(IBKRProvider, ib))
+    price = provider.get_price("SYM", "last")
+    assert price == pytest.approx(100.0)
+
+
+def test_stale_quote_uses_snapshot() -> None:
+    now = datetime.now(timezone.utc) - timedelta(seconds=20)
+    contracts = {"SYM": Contract(symbol="SYM")}
+    quotes = {"SYM": Quote(bid=None, ask=None, ts=now, last=99.5)}
+    ib = FakeIB(contracts=contracts, quotes=quotes)
+    provider = IBKRQuoteProvider(
+        cast(IBKRProvider, ib), stale_quote_seconds=10, snapshots={"SYM": 98.7}
+    )
+    price = provider.get_price("SYM", "last", fallback_to_snapshot=True)
+    assert price == pytest.approx(98.7)
+    with pytest.raises(ValueError):
+        provider.get_price("SYM", "last")


### PR DESCRIPTION
## Summary
- add IBKRQuoteProvider to fetch quotes via an IBKRProvider, including FX pair resolution
- support price retrieval with last→midpoint→bid/ask fallback and optional snapshot prices
- expose IBKRQuoteProvider through pricing module and test with FakeIB

## Testing
- `pre-commit run --files ibkr_etf_rebalancer/pricing.py tests/test_ibkr_quote_provider.py tests/test_pricing.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0fb55369c83209ac5442f1acb659e