### PR TITLE
test: ensure unmapped symbols raise

### DIFF
--- a/tests/test_ibkr_provider.py
+++ b/tests/test_ibkr_provider.py
@@ -15,6 +15,7 @@ from ibkr_etf_rebalancer.ibkr_provider import (
     OrderSide,
     OrderType,
     PacingError,
+    ResolutionError,
 )
 
 
@@ -81,6 +82,12 @@ def test_resolve_contract_with_symbol_overrides() -> None:
     assert ib.resolve_contract(Contract(symbol="BBB")) == contracts["AAA"]
     # FX is overridden to the provided Contract instance
     assert ib.resolve_contract(Contract(symbol="FX")) == overrides["FX"]
+
+
+def test_resolve_contract_unmapped_symbol_raises() -> None:
+    ib = FakeIB(contracts={"AAA": Contract(symbol="AAA")})
+    with pytest.raises(ResolutionError):
+        ib.resolve_contract(Contract(symbol="ZZZ"))
 
 
 def test_get_quote_fresh_stale_bid_only_ask_only() -> None:


### PR DESCRIPTION
## Summary
- extend IBKR provider tests with case for resolving unknown symbols

## Testing
- `pytest tests/test_ibkr_provider.py`

------
https://chatgpt.com/codex/tasks/task_e_68b10701e1cc8320900a0a0fe470e25e