### PR TITLE
Expose FakeIB event log

### DIFF
--- a/ibkr_etf_rebalancer/ibkr_provider.py
+++ b/ibkr_etf_rebalancer/ibkr_provider.py
@@ -336,6 +336,12 @@ class FakeIB:
     def get_positions(self) -> Sequence[Position]:
         return list(self._positions)
 
+    @property
+    def event_log(self) -> Sequence[dict[str, object]]:
+        """Return a snapshot of the internal event log."""
+
+        return list(self._event_log)
+
     # --- event helpers -------------------------------------------------
     def _timestamp(self) -> datetime:
         """Return a monotonic timestamp."""

--- a/tests/test_ibkr_provider.py
+++ b/tests/test_ibkr_provider.py
@@ -196,6 +196,18 @@ def test_order_lifecycle_and_fills() -> None:
     ib.cancel(buy_open_id)
     assert buy_open_id not in ib._orders
 
+    events = ib.event_log
+    assert [(e["type"], e["order_id"]) for e in events] == [
+        ("placed", buy_open_id),
+        ("placed", sell_fill_id),
+        ("placed", fx_mkt_id),
+        ("placed", sell_mkt_id),
+        ("filled", sell_fill_id),
+        ("filled", fx_mkt_id),
+        ("filled", sell_mkt_id),
+        ("canceled", buy_open_id),
+    ]
+
 
 def test_pacing_limit_triggers_backoff_hook() -> None:
     contract = Contract(symbol="AAA")


### PR DESCRIPTION
## Summary
- add read-only `event_log` property to `FakeIB`
- validate that placing, filling, and canceling orders log events

## Testing
- `pre-commit run --files ibkr_etf_rebalancer/ibkr_provider.py tests/test_ibkr_provider.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b10802e1f88320b9f37b31ad9935f5