### PR TITLE
fix mypy override error in tests

### DIFF
--- a/tests/test_ibkr_quote_provider.py
+++ b/tests/test_ibkr_quote_provider.py
@@ -120,7 +120,7 @@ def test_fx_resolve_fallback() -> None:
 
 
 class IBQuoteFakeIB(FakeIB):
-    def get_quote(self, contract: Contract) -> IBQuote:
+    def get_quote(self, contract: Contract) -> IBQuote:  # type: ignore[override]
         resolved = self.resolve_contract(contract)
         q = self._quotes[resolved.symbol]
         return IBQuote(contract=resolved, bid=q.bid, ask=q.ask, last=q.last, timestamp=q.ts)


### PR DESCRIPTION
## Summary
- silence mypy override warning in IBQuoteFakeIB by ignoring type mismatch

## Testing
- `pytest`
- `mypy --install-types --non-interactive .`


------
https://chatgpt.com/codex/tasks/task_e_68b10b020d708320afd67119cf3bba4f