### PR TITLE
Add Phase 4 FX planning release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,17 @@
 
 ## [Unreleased]
 - Placeholder for upcoming changes.
-- Added FX planning with `[fx]` configuration for offline CAD→USD conversions.
 - Document paper and live CLI examples in `workflow.md`.
 - Clarified Definition of Done in `plan.md` to include CHANGELOG entries and SRS acceptance-criteria references.
-
-- Preserve FX bid/ask by using `get_quote` and pass full quotes to the FX planner; tests ensure limit prices respect spreads.
-
 - Expanded Phase 1 checklist with module-specific items, leverage test, and PR gate updates.
-
 - Added Phase 0 review checklist.
 
 
 ## Phase 5
 - Export provider and quote provider classes via package API. [SRS AC3][SRS AC9]
+
+## Phase 4
+- Added FX planning with `[fx]` configuration for offline CAD→USD conversions and preserved FX bid/ask spreads when sizing funding orders. [SRS AC5][SRS AC12]
 
 ## Phase 3
 - Support account snapshots via `AccountSnapshot` and `compute_account_state` exports. [SRS AC3]


### PR DESCRIPTION
## Summary
- document FX planning release notes in new Phase 4 section of changelog
- ensure phases listed in descending order from Phase 5 to Phase 0

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b11004546c8320bd4568d62356e56e