### PR TITLE
Add order executor sequencing and integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Clarified Definition of Done in `plan.md` to include CHANGELOG entries and SRS acceptance-criteria references.
 - Expanded Phase 1 checklist with module-specific items, leverage test, and PR gate updates.
 - Added Phase 0 review checklist.
+- Added integration test covering FX → SELL → BUY order sequencing with `FakeIB`.
 
 
 ## Phase 5

--- a/ibkr_etf_rebalancer/order_executor.py
+++ b/ibkr_etf_rebalancer/order_executor.py
@@ -3,6 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Sequence
+
+from .ibkr_provider import Fill, IBKRProvider, Order
+
+__all__ = ["OrderExecutionOptions", "execute_orders"]
 
 
 @dataclass
@@ -22,3 +27,42 @@ class OrderExecutionOptions:
     report_only: bool = False
     dry_run: bool = False
     yes: bool = False
+
+
+def execute_orders(
+    ib: IBKRProvider,
+    *,
+    fx_orders: Sequence[Order] | None = None,
+    sell_orders: Sequence[Order] | None = None,
+    buy_orders: Sequence[Order] | None = None,
+) -> Sequence[Fill]:
+    """Place FX, then SELL, then BUY orders using ``ib``.
+
+    Each group of orders is submitted and awaited before the next group is
+    processed to ensure deterministic sequencing.
+
+    Parameters
+    ----------
+    ib:
+        Provider used for order placement.
+    fx_orders, sell_orders, buy_orders:
+        Order groups to place sequentially. ``None`` is treated as an empty
+        sequence.
+
+    Returns
+    -------
+    Sequence[Fill]
+        Fills returned by the provider for all orders.
+    """
+
+    fx_orders = fx_orders or ()
+    sell_orders = sell_orders or ()
+    buy_orders = buy_orders or ()
+
+    fills: list[Fill] = []
+    for group in (fx_orders, sell_orders, buy_orders):
+        if not group:
+            continue
+        order_ids = [ib.place_order(o) for o in group]
+        fills.extend(ib.wait_for_fills(order_ids))
+    return fills

--- a/tests/test_order_executor.py
+++ b/tests/test_order_executor.py
@@ -1,0 +1,96 @@
+from datetime import datetime, timezone
+from typing import cast
+
+from ibkr_etf_rebalancer import pricing
+from ibkr_etf_rebalancer.ibkr_provider import (
+    Contract,
+    FakeIB,
+    IBKRProvider,
+    IBKRProviderOptions,
+    Order,
+    Fill,
+    OrderSide,
+    OrderType,
+)
+from ibkr_etf_rebalancer.order_executor import execute_orders
+
+
+def test_execute_orders_sequences_fx_sell_buy() -> None:
+    now = datetime.now(timezone.utc)
+
+    contracts = {
+        "AAA": Contract(symbol="AAA"),
+        "USD": Contract(symbol="USD", sec_type="CASH", currency="CAD", exchange="IDEALPRO"),
+    }
+    quotes = {
+        "AAA": pricing.Quote(bid=99.0, ask=100.0, ts=now, last=99.5),
+        "USD": pricing.Quote(bid=1.25, ask=1.26, ts=now, last=1.255),
+    }
+    opts = IBKRProviderOptions(allow_market_orders=True)
+    ib = FakeIB(options=opts, contracts=contracts, quotes=quotes)
+
+    fx_order = Order(
+        contract=contracts["USD"],
+        side=OrderSide.BUY,
+        quantity=1000,
+        order_type=OrderType.MARKET,
+    )
+    sell1 = Order(
+        contract=contracts["AAA"],
+        side=OrderSide.SELL,
+        quantity=5,
+        order_type=OrderType.LIMIT,
+        limit_price=98.0,
+    )
+    sell2 = Order(
+        contract=contracts["AAA"],
+        side=OrderSide.SELL,
+        quantity=1,
+        order_type=OrderType.LIMIT,
+        limit_price=97.0,
+    )
+    buy = Order(
+        contract=contracts["AAA"],
+        side=OrderSide.BUY,
+        quantity=3,
+        order_type=OrderType.LIMIT,
+        limit_price=101.0,
+    )
+
+    fills = execute_orders(
+        cast(IBKRProvider, ib),
+        fx_orders=[fx_order],
+        sell_orders=[sell1, sell2],
+        buy_orders=[buy],
+    )
+
+    assert [f.contract.symbol for f in fills] == ["USD", "AAA", "AAA", "AAA"]
+    assert [f.side for f in fills] == [
+        OrderSide.BUY,
+        OrderSide.SELL,
+        OrderSide.SELL,
+        OrderSide.BUY,
+    ]
+
+    events = [
+        (
+            e["type"],
+            (
+                cast(Order, e["order"]).contract
+                if e["type"] == "placed"
+                else cast(Fill, e["fill"]).contract
+            ).symbol,
+            (cast(Order, e["order"]).side if e["type"] == "placed" else cast(Fill, e["fill"]).side),
+        )
+        for e in ib.event_log
+    ]
+    assert events == [
+        ("placed", "USD", OrderSide.BUY),
+        ("filled", "USD", OrderSide.BUY),
+        ("placed", "AAA", OrderSide.SELL),
+        ("placed", "AAA", OrderSide.SELL),
+        ("filled", "AAA", OrderSide.SELL),
+        ("filled", "AAA", OrderSide.SELL),
+        ("placed", "AAA", OrderSide.BUY),
+        ("filled", "AAA", OrderSide.BUY),
+    ]


### PR DESCRIPTION
## Summary
- implement execute_orders to place FX, then SELL, then BUY orders
- add integration test verifying sequencing with FakeIB

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b11323b5d083208b34f5cff3bf50c7