### PR TITLE
Add trading safety confirmation and RTH checks

### DIFF
--- a/ibkr_etf_rebalancer/safety.py
+++ b/ibkr_etf_rebalancer/safety.py
@@ -9,46 +9,82 @@ area small while still being easy to reason about in tests.
 
 from __future__ import annotations
 
+from datetime import datetime, time
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 
 def check_kill_switch(path: str | Path | None) -> None:
-    """Abort if a *kill switch* file exists.
+    """Abort if a *kill switch* file exists."""
+
+    if path is None:
+        return
+    kill_switch = Path(path).expanduser()
+    if kill_switch.exists():
+        raise RuntimeError(f"kill switch engaged: {kill_switch}")
+
+
+def ensure_paper_trading(paper: bool, live: bool) -> None:
+    """Ensure the application is running in paper mode."""
+
+    if live:
+        raise RuntimeError("live trading explicitly requested")
+    if not paper:
+        raise RuntimeError("not connected to paper trading environment")
+
+
+def require_confirmation(msg: str, assume_yes: bool) -> None:
+    """Prompt the user for confirmation.
 
     Parameters
     ----------
-    path:
-        Path to the kill switch file.  If ``None`` the check is skipped.
+    msg:
+        Message to display to the user.
+    assume_yes:
+        If ``True`` the confirmation is skipped.
 
     Raises
     ------
     RuntimeError
-        If the file exists.
+        If the user rejects the confirmation.
     """
 
-    if path is None:
+    if assume_yes:
         return
-    if Path(path).expanduser().exists():
-        raise RuntimeError("kill switch engaged")
+    answer = input(f"{msg} [y/N]: ").strip().lower()
+    if answer not in {"y", "yes"}:
+        raise RuntimeError("confirmation rejected")
 
 
-def ensure_paper_trading(paper: bool, live: bool) -> None:
-    """Ensure the application is running in paper mode.
+def ensure_regular_trading_hours(now: datetime, prefer_rth: bool) -> None:
+    """Ensure operations occur during regular trading hours.
 
-    The function raises :class:`RuntimeError` if live trading is requested
-    without explicit permission.  This is primarily used in the test
-    environment where live trading should never occur.
-
-    Parameters
-    ----------
-    paper:
-        ``True`` when connected to a paper trading environment.
-    live:
-        ``True`` when live trading is explicitly requested.
+    ``RuntimeError`` is raised when ``prefer_rth`` is ``True`` and *now*
+    falls outside 09:30–16:00 Eastern on a weekday.
     """
 
-    if live or not paper:
-        raise RuntimeError("live trading not allowed")
+    if not prefer_rth:
+        return
+
+    eastern = ZoneInfo("America/New_York")
+    if now.tzinfo is None:
+        now_eastern = now.replace(tzinfo=eastern)
+    else:
+        now_eastern = now.astimezone(eastern)
+
+    if now_eastern.weekday() >= 5:
+        raise RuntimeError("outside regular trading hours: weekend")
+
+    start = time(9, 30)
+    end = time(16, 0)
+    current = now_eastern.time()
+    if not (start <= current <= end):
+        raise RuntimeError("outside regular trading hours: after-hours")
 
 
-__all__ = ["check_kill_switch", "ensure_paper_trading"]
+__all__ = [
+    "check_kill_switch",
+    "ensure_paper_trading",
+    "require_confirmation",
+    "ensure_regular_trading_hours",
+]

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,0 +1,57 @@
+import builtins
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+from freezegun import freeze_time
+
+from ibkr_etf_rebalancer.safety import (
+    check_kill_switch,
+    ensure_paper_trading,
+    ensure_regular_trading_hours,
+    require_confirmation,
+)
+
+
+def test_require_confirmation_accept(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(builtins, "input", lambda _: "y")
+    require_confirmation("Proceed?", assume_yes=False)
+
+
+def test_require_confirmation_reject(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(builtins, "input", lambda _: "n")
+    with pytest.raises(RuntimeError):
+        require_confirmation("Proceed?", assume_yes=False)
+
+
+def test_check_kill_switch(tmp_path: Path) -> None:
+    kill_file = tmp_path / "kill"
+    kill_file.write_text("")
+    with pytest.raises(RuntimeError):
+        check_kill_switch(kill_file)
+    # Non-existent file should pass
+    check_kill_switch(tmp_path / "other")
+
+
+@pytest.mark.parametrize(
+    "paper,live",
+    [(True, True), (False, False)],
+)
+def test_ensure_paper_trading_guard(paper: bool, live: bool) -> None:
+    with pytest.raises(RuntimeError):
+        ensure_paper_trading(paper=paper, live=live)
+
+
+def test_ensure_regular_trading_hours_weekend() -> None:
+    with freeze_time("2024-01-06 12:00:00-05:00"):
+        now = datetime.now(tz=ZoneInfo("America/New_York"))
+        with pytest.raises(RuntimeError):
+            ensure_regular_trading_hours(now, prefer_rth=True)
+
+
+def test_ensure_regular_trading_hours_after_hours() -> None:
+    with freeze_time("2024-01-08 17:00:00-05:00"):
+        now = datetime.now(tz=ZoneInfo("America/New_York"))
+        with pytest.raises(RuntimeError):
+            ensure_regular_trading_hours(now, prefer_rth=True)


### PR DESCRIPTION
## Summary
- add `require_confirmation` to enforce explicit operator confirmation
- gate operations outside regular trading hours with `ensure_regular_trading_hours`
- improve kill switch and paper-trading runtime messages
- test safety helpers including confirmation, kill switch, paper-only guard, and RTH gating

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b11b8426cc8320b886ccaa04343a38