### PR TITLE
Add order builder with limit pricing and FX support

### DIFF
--- a/ibkr_etf_rebalancer/order_builder.py
+++ b/ibkr_etf_rebalancer/order_builder.py
@@ -1,3 +1,132 @@
-"""Order Builder module."""
+"""Order construction helpers.
 
-# TODO: implement order builder
+This module translates high level rebalance plans into concrete broker
+``Order`` objects.  The functions are intentionally lightweight: they perform
+basic validation, apply limit prices when requested and ensure prices respect
+contract tick sizes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Mapping
+
+from . import limit_pricer
+from .config import LimitsConfig, RebalanceConfig
+from .fx_engine import FxPlan
+from .ibkr_provider import Contract, Order, OrderSide, OrderType
+from .pricing import Quote
+
+__all__ = ["build_equity_orders", "build_fx_order"]
+
+
+def _min_tick(contract: Contract) -> float:
+    """Return the contract's minimum tick if available."""
+
+    tick = getattr(contract, "min_tick", 0.01)
+    try:
+        tick = float(tick)
+    except Exception:  # pragma: no cover - defensive
+        tick = 0.01
+    if tick <= 0:  # pragma: no cover - defensive
+        tick = 0.01
+    return tick
+
+
+def build_equity_orders(
+    plan: Mapping[str, float],
+    quotes: Mapping[str, Quote],
+    cfg: RebalanceConfig | SimpleNamespace,
+    contracts: Mapping[str, Contract],
+) -> list[Order]:
+    """Return ``Order`` objects for an equity rebalance *plan*.
+
+    ``plan`` maps symbols to share deltas (positive for buys, negative for
+    sells).  ``quotes`` provides current market quotes used for limit pricing
+    while ``contracts`` supplies the corresponding broker contract objects.  The
+    ``cfg`` object must provide ``order_type`` and may optionally supply a
+    ``limits`` attribute containing a :class:`LimitsConfig` instance.  When
+    ``cfg.order_type`` is ``"LMT"`` the :mod:`limit_pricer` helpers are used to
+    calculate conservative limit prices.  If the limit pricer escalates to
+    market the order type is switched to ``"MKT"``.
+    """
+
+    limit_cfg = getattr(cfg, "limits", LimitsConfig())
+    now = datetime.now(timezone.utc)
+    orders: list[Order] = []
+
+    for symbol, qty in plan.items():
+        if symbol not in contracts or symbol not in quotes:
+            raise KeyError(f"missing data for {symbol}")
+
+        if qty == 0:
+            raise ValueError(f"non-zero quantity required for {symbol}")
+
+        side = OrderSide.BUY if qty > 0 else OrderSide.SELL
+        quantity = abs(qty)
+        if quantity <= 0:  # pragma: no cover - defensive
+            raise ValueError(f"non-positive quantity for {symbol}")
+
+        contract = contracts[symbol]
+        quote = quotes[symbol]
+
+        order_type = OrderType.LIMIT if cfg.order_type == "LMT" else OrderType.MARKET
+        limit_price: float | None = None
+
+        if order_type is OrderType.LIMIT:
+            tick = _min_tick(contract)
+            if side is OrderSide.BUY:
+                price, kind = limit_pricer.price_limit_buy(quote, tick, limit_cfg, now)
+            else:
+                price, kind = limit_pricer.price_limit_sell(quote, tick, limit_cfg, now)
+            if kind == "MKT":
+                order_type = OrderType.MARKET
+            else:
+                limit_price = price
+
+        orders.append(
+            Order(
+                contract=contract,
+                side=side,
+                quantity=quantity,
+                order_type=order_type,
+                limit_price=limit_price,
+            )
+        )
+
+    return orders
+
+
+def build_fx_order(fx_plan: FxPlan, contract: Contract) -> Order:
+    """Return an FX ``Order`` from ``fx_plan``.
+
+    The plan's quantity is rounded to two decimal places while limit prices are
+    rounded to the nearest pip (``0.0001``) or the contract's ``min_tick`` if it
+    specifies one.  ``fx_plan.side`` determines the order side.  ``fx_plan`` is
+    assumed to describe a required conversion; callers should ensure
+    ``fx_plan.need_fx`` before invoking this function.
+    """
+
+    qty = round(fx_plan.qty, 2)
+    if qty <= 0:
+        raise ValueError("fx quantity must be positive")
+
+    side = OrderSide(fx_plan.side)
+    order_type = OrderType.LIMIT if fx_plan.order_type == "LMT" else OrderType.MARKET
+    limit_price: float | None = None
+
+    if order_type is OrderType.LIMIT:
+        if fx_plan.limit_price is None:
+            raise ValueError("limit price required for LMT FX order")
+        tick = getattr(contract, "min_tick", 0.0001) or 0.0001
+        limit_price = round(round(fx_plan.limit_price / tick) * tick, 4)
+
+    return Order(
+        contract=contract,
+        side=side,
+        quantity=qty,
+        order_type=order_type,
+        limit_price=limit_price,
+    )
+

--- a/tests/test_order_builder.py
+++ b/tests/test_order_builder.py
@@ -1,0 +1,121 @@
+"""Tests for :mod:`order_builder`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from ibkr_etf_rebalancer.config import LimitsConfig
+from ibkr_etf_rebalancer.fx_engine import FxPlan
+from ibkr_etf_rebalancer.ibkr_provider import Contract, OrderSide, OrderType
+from ibkr_etf_rebalancer.order_builder import build_equity_orders, build_fx_order
+from ibkr_etf_rebalancer.pricing import FakeQuoteProvider, Quote
+
+
+@dataclass(frozen=True)
+class ContractWithTick(Contract):
+    min_tick: float = 0.01
+
+
+def test_buy_vs_sell_mapping() -> None:
+    """Positive quantities map to BUY and negative to SELL."""
+
+    now = datetime.now(timezone.utc)
+    provider = FakeQuoteProvider(
+        {
+            "AAA": Quote(bid=99.9, ask=100.1, ts=now),
+            "BBB": Quote(bid=49.9, ask=50.1, ts=now),
+        }
+    )
+    quotes = {sym: provider.get_quote(sym) for sym in ("AAA", "BBB")}
+    contracts = {
+        "AAA": ContractWithTick(symbol="AAA", min_tick=0.05),
+        "BBB": ContractWithTick(symbol="BBB", min_tick=0.05),
+    }
+    plan = {"AAA": 10, "BBB": -5}
+    cfg = SimpleNamespace(order_type="LMT", limits=LimitsConfig())
+
+    orders = build_equity_orders(plan, quotes, cfg, contracts)
+    by_symbol = {o.contract.symbol: o for o in orders}
+
+    assert by_symbol["AAA"].side is OrderSide.BUY
+    assert by_symbol["BBB"].side is OrderSide.SELL
+
+
+def test_fx_order_creation() -> None:
+    """FX plans are turned into rounded FX orders."""
+
+    fx_plan = FxPlan(
+        need_fx=True,
+        pair="USD.CAD",
+        side="BUY",
+        usd_notional=1000.0,
+        est_rate=1.25057,
+        qty=1000.123,
+        order_type="LMT",
+        limit_price=1.25057,
+        route="IDEALPRO",
+        wait_for_fill_seconds=0,
+        reason="test",
+    )
+    contract = ContractWithTick(
+        symbol="USD", sec_type="CASH", currency="CAD", exchange="IDEALPRO", min_tick=0.0001
+    )
+
+    order = build_fx_order(fx_plan, contract)
+    assert order.side is OrderSide.BUY
+    assert order.order_type is OrderType.LIMIT
+    assert order.quantity == pytest.approx(1000.12, rel=1e-6)
+    assert order.limit_price == pytest.approx(1.2506, rel=1e-6)
+
+
+def test_order_type_switch_between_lmt_and_mkt() -> None:
+    """Orders honour the requested ``order_type``."""
+
+    now = datetime.now(timezone.utc)
+    quotes = {"AAA": Quote(bid=99.0, ask=101.0, ts=now)}
+    contracts = {"AAA": Contract(symbol="AAA")}
+    plan = {"AAA": 10}
+    cfg = SimpleNamespace(order_type="MKT", limits=LimitsConfig())
+
+    orders = build_equity_orders(plan, quotes, cfg, contracts)
+    order = orders[0]
+    assert order.order_type is OrderType.MARKET
+    assert order.limit_price is None
+
+
+def test_escalation_to_market_on_limit_instruction() -> None:
+    """Wide markets escalate limit orders to market orders."""
+
+    now = datetime.now(timezone.utc)
+    quotes = {"AAA": Quote(bid=100.0, ask=101.0, ts=now)}
+    contracts = {"AAA": Contract(symbol="AAA")}
+    limits = LimitsConfig(escalate_action="market", wide_spread_bps=1)
+    cfg = SimpleNamespace(order_type="LMT", limits=limits)
+    plan = {"AAA": 10}
+
+    orders = build_equity_orders(plan, quotes, cfg, contracts)
+    order = orders[0]
+    assert order.order_type is OrderType.MARKET
+    assert order.limit_price is None
+
+
+def test_limit_prices_capped_at_nbbo() -> None:
+    """Limit prices never cross the current NBBO."""
+
+    now = datetime.now(timezone.utc)
+    provider = FakeQuoteProvider({"AAA": Quote(bid=100.0, ask=100.2, ts=now)})
+    quotes = {"AAA": provider.get_quote("AAA")}
+    contracts = {"AAA": ContractWithTick(symbol="AAA", min_tick=0.05)}
+    plan = {"AAA": 10}
+    cfg = SimpleNamespace(order_type="LMT", limits=LimitsConfig())
+
+    orders = build_equity_orders(plan, quotes, cfg, contracts)
+    order = orders[0]
+    assert order.limit_price <= quotes["AAA"].ask
+    # tick rounding honoured
+    assert abs(order.limit_price / 0.05 - round(order.limit_price / 0.05)) < 1e-9
+


### PR DESCRIPTION
## Summary
- implement equity order construction using spread-aware limit pricing
- add FX order builder with pip rounding
- cover order building scenarios with unit tests

## Testing
- `pytest tests/test_order_builder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b11d03e01c8320bf8e9c8037b4173b