### PR TITLE
feat: add execution safety and concurrency

### DIFF
--- a/ibkr_etf_rebalancer/order_executor.py
+++ b/ibkr_etf_rebalancer/order_executor.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
+import time
+import logging
 from typing import Sequence
 
+from . import safety
+from .fx_engine import FxPlan
 from .ibkr_provider import Fill, IBKRProvider, Order
 
 __all__ = ["OrderExecutionOptions", "execute_orders"]
@@ -22,11 +27,17 @@ class OrderExecutionOptions:
         Simulate the execution flow without side effects.
     yes:
         Automatically answer affirmatively to confirmation prompts.
+    concurrency_cap:
+        Maximum number of concurrent orders to maintain. ``None`` for no cap.
+    prefer_rth:
+        Require regular trading hours before placing orders.
     """
 
     report_only: bool = False
     dry_run: bool = False
     yes: bool = False
+    concurrency_cap: int | None = None
+    prefer_rth: bool = False
 
 
 def execute_orders(
@@ -35,7 +46,9 @@ def execute_orders(
     fx_orders: Sequence[Order] | None = None,
     sell_orders: Sequence[Order] | None = None,
     buy_orders: Sequence[Order] | None = None,
-) -> Sequence[Fill]:
+    fx_plan: FxPlan | None = None,
+    options: OrderExecutionOptions | None = None,
+) -> Sequence[Fill] | Sequence[Order]:
     """Place FX, then SELL, then BUY orders using ``ib``.
 
     Each group of orders is submitted and awaited before the next group is
@@ -48,21 +61,57 @@ def execute_orders(
     fx_orders, sell_orders, buy_orders:
         Order groups to place sequentially. ``None`` is treated as an empty
         sequence.
+    fx_plan:
+        Optional :class:`FxPlan` used to insert a pause after FX fills.
+    options:
+        Execution options controlling behaviour.
 
     Returns
     -------
-    Sequence[Fill]
-        Fills returned by the provider for all orders.
+    Sequence[Fill] | Sequence[Order]
+        Planned orders when ``report_only`` or ``dry_run`` is set, otherwise
+        fills returned by the provider for all orders.
     """
+
+    logger = logging.getLogger(__name__)
+    options = options or OrderExecutionOptions()
+
+    safety.check_kill_switch(ib.options.kill_switch)
+    safety.ensure_paper_trading(ib.options.paper, ib.options.live)
+    safety.ensure_regular_trading_hours(datetime.now(timezone.utc), options.prefer_rth)
+    safety.require_confirmation("Proceed with order placement?", options.yes)
 
     fx_orders = fx_orders or ()
     sell_orders = sell_orders or ()
     buy_orders = buy_orders or ()
 
+    planned = list(fx_orders) + list(sell_orders) + list(buy_orders)
+
+    logger.info("planned_orders", extra={"count": len(planned)})
+    if options.report_only or options.dry_run or ib.options.dry_run:
+        return planned
+
     fills: list[Fill] = []
-    for group in (fx_orders, sell_orders, buy_orders):
+
+    def _submit_group(group_name: str, group: Sequence[Order]) -> None:
         if not group:
-            continue
-        order_ids = [ib.place_order(o) for o in group]
-        fills.extend(ib.wait_for_fills(order_ids))
+            return
+        cap = options.concurrency_cap
+        batches = [list(group)] if cap in (None, 0) else [list(group[i : i + cap]) for i in range(0, len(group), cap)]
+        for batch in batches:
+            order_ids = [ib.place_order(o) for o in batch]
+            logger.info("orders_submitted", extra={"group": group_name, "count": len(batch)})
+            fills.extend(ib.wait_for_fills(order_ids))
+            logger.info("orders_filled", extra={"group": group_name, "count": len(order_ids)})
+
+    _submit_group("fx", fx_orders)
+
+    if fx_plan and fx_plan.wait_for_fill_seconds > 0:
+        logger.info("fx_pause", extra={"seconds": fx_plan.wait_for_fill_seconds})
+        time.sleep(fx_plan.wait_for_fill_seconds)
+
+    _submit_group("sell", sell_orders)
+    _submit_group("buy", buy_orders)
+
+    logger.info("fills_collected", extra={"count": len(fills)})
     return fills


### PR DESCRIPTION
## Summary
- extend `OrderExecutionOptions` with concurrency cap and RTH preference
- add safety checks, batching, and FX pacing to `execute_orders`
- test dry-run behaviour, order sequencing, concurrency, and safety gates

## Testing
- `ruff check ibkr_etf_rebalancer/order_executor.py tests/test_order_executor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b11e48729883209551badd4fa09fe2