### PR TITLE
Handle optional concurrency cap and assert non-null limit prices

### DIFF
--- a/ibkr_etf_rebalancer/order_executor.py
+++ b/ibkr_etf_rebalancer/order_executor.py
@@ -101,10 +101,7 @@ def execute_orders(
             batches = [list(group)]
         else:
             nonzero_cap = cap
-            batches = [
-                list(group[i : i + nonzero_cap])
-                for i in range(0, len(group), nonzero_cap)
-            ]
+            batches = [list(group[i : i + nonzero_cap]) for i in range(0, len(group), nonzero_cap)]
         for batch in batches:
             order_ids = [ib.place_order(o) for o in batch]
             logger.info("orders_submitted", extra={"group": group_name, "count": len(batch)})

--- a/ibkr_etf_rebalancer/order_executor.py
+++ b/ibkr_etf_rebalancer/order_executor.py
@@ -97,11 +97,14 @@ def execute_orders(
         if not group:
             return
         cap = options.concurrency_cap
-        batches = (
-            [list(group)]
-            if cap in (None, 0)
-            else [list(group[i : i + cap]) for i in range(0, len(group), cap)]
-        )
+        if cap is None or cap == 0:
+            batches = [list(group)]
+        else:
+            nonzero_cap = cap
+            batches = [
+                list(group[i : i + nonzero_cap])
+                for i in range(0, len(group), nonzero_cap)
+            ]
         for batch in batches:
             order_ids = [ib.place_order(o) for o in batch]
             logger.info("orders_submitted", extra={"group": group_name, "count": len(batch)})

--- a/tests/test_order_builder.py
+++ b/tests/test_order_builder.py
@@ -115,6 +115,10 @@ def test_limit_prices_capped_at_nbbo() -> None:
 
     orders = build_equity_orders(plan, quotes, cfg, contracts)
     order = orders[0]
-    assert order.limit_price <= quotes["AAA"].ask
+    assert order.limit_price is not None
+    limit_price = order.limit_price
+    ask = quotes["AAA"].ask
+    assert ask is not None
+    assert limit_price <= ask
     # tick rounding honoured
-    assert abs(order.limit_price / 0.05 - round(order.limit_price / 0.05)) < 1e-9
+    assert abs(limit_price / 0.05 - float(round(limit_price / 0.05))) < 1e-9


### PR DESCRIPTION
## Summary
- Refine order batching to avoid Optional[int] arithmetic when concurrency cap is set
- Clarify test expectations by asserting non-`None` limit prices before comparisons

## Testing
- `mypy --strict --pretty ibkr_etf_rebalancer/order_executor.py tests/test_order_builder.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b120201d508320bfea744067d859fc