### PR TITLE
feat: enhance post-trade reporting

### DIFF
--- a/tests/golden/post_trade_report.csv
+++ b/tests/golden/post_trade_report.csv
@@ -1,3 +1,3 @@
-symbol,side,filled_shares,avg_price,notional
-AAA,BUY,100.0,10.0,1000.0
-BBB,SELL,-50.0,20.0,-1000.0
+symbol,side,filled_shares,avg_price,notional,residual_drift_bps
+AAA,BUY,100.0,10.0,1000.0,900.0
+BBB,SELL,-50.0,20.0,-1000.0,-900.0

--- a/tests/golden/post_trade_report.md
+++ b/tests/golden/post_trade_report.md
@@ -1,0 +1,4 @@
+| symbol | side | filled_shares | avg_price | notional | residual_drift_bps |
+| --- | --- | --- | --- | --- | --- |
+| AAA | BUY | 100.0000 | 10.00 | 1000.00 | 900.00 |
+| BBB | SELL | -50.0000 | 20.00 | -1000.00 | -900.00 |


### PR DESCRIPTION
## Summary
- extend post-trade reporting to compute residual drift vs targets
- support writing post-trade reports to timestamped CSV and Markdown
- add tests and golden files for post-trade reports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b123aed51883208c9371c8bb056c10