### PR TITLE
Add RTH preference to order builders

### DIFF
--- a/ibkr_etf_rebalancer/order_builder.py
+++ b/ibkr_etf_rebalancer/order_builder.py
@@ -106,9 +106,7 @@ def build_equity_orders(
     return orders
 
 
-def build_fx_order(
-    fx_plan: FxPlan, contract: Contract, prefer_rth: bool = True
-) -> Order:
+def build_fx_order(fx_plan: FxPlan, contract: Contract, prefer_rth: bool = True) -> Order:
     """Return an FX ``Order`` from ``fx_plan``.
 
     The plan's quantity is rounded to two decimal places while limit prices are


### PR DESCRIPTION
## Summary
- Allow equity and FX order builders to disable regular-trading-hours preference
- Test that orders use RTH flags according to the new `prefer_rth` parameter

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b127849f308320a7de7e6454362ec7