### PR TITLE
Handle partial and timed-out orders

### DIFF
--- a/ibkr_etf_rebalancer/order_executor.py
+++ b/ibkr_etf_rebalancer/order_executor.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-import time
 import logging
+import time
 from typing import Sequence
 
 from . import safety
@@ -21,6 +21,7 @@ from .ibkr_provider import (
 
 __all__ = [
     "OrderExecutionOptions",
+    "OrderExecutionResult",
     "ExecutionError",
     "ConnectionError",
     "PacingError",
@@ -87,6 +88,25 @@ class OrderExecutionOptions:
     prefer_rth: bool = False
 
 
+@dataclass
+class OrderExecutionResult:
+    """Return value from :func:`execute_orders` when orders are placed.
+
+    Attributes
+    ----------
+    fills:
+        Fills returned by the provider.
+    canceled:
+        Orders that were canceled due to timeout or partial fills.
+    timed_out:
+        ``True`` if any batch timed out while waiting for fills.
+    """
+
+    fills: list[Fill]
+    canceled: list[Order]
+    timed_out: bool = False
+
+
 def execute_orders(
     ib: IBKRProvider,
     *,
@@ -95,7 +115,7 @@ def execute_orders(
     buy_orders: Sequence[Order] | None = None,
     fx_plan: FxPlan | None = None,
     options: OrderExecutionOptions | None = None,
-) -> Sequence[Fill] | Sequence[Order]:
+) -> OrderExecutionResult | Sequence[Order]:
     """Place FX, then SELL, then BUY orders using ``ib``.
 
     Each group of orders is submitted and awaited before the next group is
@@ -115,9 +135,9 @@ def execute_orders(
 
     Returns
     -------
-    Sequence[Fill] | Sequence[Order]
+    OrderExecutionResult | Sequence[Order]
         Planned orders when ``report_only`` or ``dry_run`` is set, otherwise
-        fills returned by the provider for all orders.
+        execution details including fills and canceled orders.
     """
 
     logger = logging.getLogger(__name__)
@@ -138,7 +158,7 @@ def execute_orders(
     if options.report_only or options.dry_run or ib.options.dry_run:
         return planned
 
-    fills: list[Fill] = []
+    result = OrderExecutionResult(fills=[], canceled=[])
 
     def _translate_error(exc: Exception) -> ExecutionError:
         if isinstance(exc, ProviderPacingError):
@@ -166,11 +186,38 @@ def execute_orders(
             except Exception as exc:  # pragma: no cover - defensive
                 raise _translate_error(exc) from exc
             logger.info("orders_submitted", extra={"group": group_name, "count": len(batch)})
+            id_to_order = dict(zip(order_ids, batch))
+            timed_out = False
             try:
-                fills.extend(ib.wait_for_fills(order_ids))
+                batch_fills = list(ib.wait_for_fills(order_ids))
+            except TimeoutError:
+                batch_fills = []
+                timed_out = True
             except Exception as exc:  # pragma: no cover - defensive
                 raise _translate_error(exc) from exc
-            logger.info("orders_filled", extra={"group": group_name, "count": len(order_ids)})
+            result.fills.extend(batch_fills)
+            remaining = set(order_ids)
+            for fill in batch_fills:
+                for oid in list(remaining):
+                    order = id_to_order[oid]
+                    if (
+                        fill.contract.symbol == order.contract.symbol
+                        and fill.side == order.side
+                        and fill.quantity == order.quantity
+                    ):
+                        remaining.remove(oid)
+                        break
+            for oid in remaining:
+                ib.cancel(oid)
+                result.canceled.append(id_to_order[oid])
+            if timed_out:
+                result.timed_out = True
+            logger.info("orders_filled", extra={"group": group_name, "count": len(batch_fills)})
+            if remaining:
+                logger.warning(
+                    "orders_unfilled",
+                    extra={"group": group_name, "count": len(remaining), "timeout": timed_out},
+                )
 
     _submit_group("fx", fx_orders)
 
@@ -181,5 +228,5 @@ def execute_orders(
     _submit_group("sell", sell_orders)
     _submit_group("buy", buy_orders)
 
-    logger.info("fills_collected", extra={"count": len(fills)})
-    return fills
+    logger.info("fills_collected", extra={"count": len(result.fills)})
+    return result


### PR DESCRIPTION
## Summary
- Add `OrderExecutionResult` with fill, cancel, and timeout details
- Cancel unfilled orders after each batch and track timeouts
- Test partial fills and wait timeouts with `FakeIB`

## Testing
- `pre-commit run --files ibkr_etf_rebalancer/order_executor.py tests/test_order_executor.py`
- `pytest tests/test_order_executor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b128991a2c8320801f7ec74b8dde8d