### PR TITLE
Fix order cancellation mismatch on partial fills

### DIFF
--- a/ibkr_etf_rebalancer/ibkr_provider.py
+++ b/ibkr_etf_rebalancer/ibkr_provider.py
@@ -92,6 +92,7 @@ class Fill:
     quantity: float
     price: float
     timestamp: datetime | None = None
+    order_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -482,6 +483,7 @@ class FakeIB:
                 quantity=order.quantity,
                 price=price,
                 timestamp=self._timestamp(),
+                order_id=oid,
             )
             fills.append(fill)
             self._log_event("filled", oid, fill=fill)

--- a/ibkr_etf_rebalancer/order_executor.py
+++ b/ibkr_etf_rebalancer/order_executor.py
@@ -198,6 +198,10 @@ def execute_orders(
             result.fills.extend(batch_fills)
             remaining = set(order_ids)
             for fill in batch_fills:
+                oid = getattr(fill, "order_id", None)
+                if oid is not None and oid in remaining:
+                    remaining.remove(oid)
+                    continue
                 for oid in list(remaining):
                     order = id_to_order[oid]
                     if (


### PR DESCRIPTION
## Summary
- include optional `order_id` on `Fill` and populate it in `FakeIB`
- match fills to orders using IDs before canceling remaining ones

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b12a91e4308320884f2423b7a8a720