### PR TITLE
docs: add phase 6 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Added integration test covering FX → SELL → BUY order sequencing with `FakeIB`.
 
 
+## Phase 6
+- Implemented order builder and executor for dry-run and paper modes with spread-aware limit pricing, FX → SELL → BUY sequencing, and safety rails. [SRS AC5][SRS AC6][SRS AC7][SRS AC12][SRS AC13]
+
 ## Phase 5
 - Export provider and quote provider classes via package API. [SRS AC3][SRS AC9]
 


### PR DESCRIPTION
## Summary
- document Phase 6 order builder and executor features in changelog

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q` *(fails: tests/test_order_executor.py::test_execute_orders_partial_fill_cancels_remaining)*

------
https://chatgpt.com/codex/tasks/task_e_68b12a9da0308320afe7b82960d6eecc