### PR TITLE
Track sell proceeds and scale buy orders

### DIFF
--- a/tests/test_order_executor.py
+++ b/tests/test_order_executor.py
@@ -270,7 +270,11 @@ def test_execute_orders_partial_sell_proceeds_scale_buy(monkeypatch: pytest.Monk
     )
 
     assert result.sell_proceeds == pytest.approx(20.0)
-    buy_event = [e for e in ib.event_log if e["type"] == "placed" and cast(Order, e["order"]).side is OrderSide.BUY][0]
+    buy_event = [
+        e
+        for e in ib.event_log
+        if e["type"] == "placed" and cast(Order, e["order"]).side is OrderSide.BUY
+    ][0]
     assert cast(Order, buy_event["order"]).quantity == pytest.approx(2.0)
 
 


### PR DESCRIPTION
## Summary
- track realized proceeds from sell order fills during execution
- add cash and leverage parameters to scale buy orders within available buying power
- test partial sell fills to ensure buy orders are scaled to proceeds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b12c91de4c8320837bf53a8ce4b2e7