### PR TITLE
feat(util): centralize basis-point conversions

### DIFF
--- a/ibkr_etf_rebalancer/fx_engine.py
+++ b/ibkr_etf_rebalancer/fx_engine.py
@@ -19,6 +19,7 @@ from typing import Literal
 
 from .config import FXConfig
 from . import pricing
+from .util import from_bps
 
 __all__ = ["FxPlan", "plan_fx_if_needed"]
 
@@ -196,7 +197,7 @@ def plan_fx_if_needed(
             reason=f"no {funding_currency} cash available",
         )
 
-    buffered = shortfall * (1 + cfg.fx_buffer_bps / 10_000)
+    buffered = shortfall * (1 + from_bps(cfg.fx_buffer_bps))
 
     if buffered < cfg.min_fx_order_usd:
         reason = f"shortfall {buffered:.2f} below min {cfg.min_fx_order_usd}"  # noqa: E501
@@ -316,7 +317,7 @@ def plan_fx_if_needed(
 
     limit_price: float | None = None
     if cfg.order_type == "LMT":
-        offset = mid * (cfg.limit_slippage_bps / 10_000)
+        offset = mid * from_bps(cfg.limit_slippage_bps)
         price = mid + offset if side == "BUY" else mid - offset
         limit_price = _round_price(price)
 

--- a/ibkr_etf_rebalancer/limit_pricer.py
+++ b/ibkr_etf_rebalancer/limit_pricer.py
@@ -14,6 +14,7 @@ import math
 
 from .config import LimitsConfig
 from .pricing import Quote, QuoteProvider, is_stale
+from .util import from_bps, to_bps
 
 __all__ = ["price_limit_buy", "price_limit_sell", "calc_limit_price"]
 
@@ -81,10 +82,10 @@ def price_limit_buy(
         raise ValueError("Quote ask must be greater than bid")
 
     mid = (bid + ask) / 2
-    spread_bps = (spread / mid) * 10000
+    spread_bps = to_bps(spread / mid)
 
     price = mid + cfg.buy_offset_frac * spread
-    cap = mid * (1 + cfg.max_offset_bps / 10000)
+    cap = mid * (1 + from_bps(cfg.max_offset_bps))
     price = min(price, cap)
     if cfg.use_ask_bid_cap:
         price = min(price, ask)
@@ -131,10 +132,10 @@ def price_limit_sell(
         raise ValueError("Quote ask must be greater than bid")
 
     mid = (bid + ask) / 2
-    spread_bps = (spread / mid) * 10000
+    spread_bps = to_bps(spread / mid)
 
     price = mid - cfg.sell_offset_frac * spread
-    cap = mid * (1 - cfg.max_offset_bps / 10000)
+    cap = mid * (1 - from_bps(cfg.max_offset_bps))
     price = max(price, cap)
     if cfg.use_ask_bid_cap:
         price = max(price, bid)

--- a/ibkr_etf_rebalancer/rebalance_engine.py
+++ b/ibkr_etf_rebalancer/rebalance_engine.py
@@ -43,6 +43,7 @@ from typing import Any, Dict, Mapping
 from .config import FXConfig, PricingConfig
 from .fx_engine import FxPlan, plan_fx_if_needed
 from .pricing import QuoteProvider
+from .util import to_bps
 
 
 def _get_band(bands: float | Mapping[str, float], symbol: str) -> float:
@@ -145,7 +146,7 @@ def generate_orders(
     if outside_band:
         actionable = outside_band
     else:
-        total_drift_bps = round(sum(abs(d) for d in diffs.values()) * 10_000, 8)
+        total_drift_bps = round(to_bps(sum(abs(d) for d in diffs.values())), 8)
         if trigger_mode == "total_drift" and total_drift_bps > portfolio_total_band_bps:
             actionable = {sym: d for sym, d in diffs.items() if d != 0}
         else:

--- a/ibkr_etf_rebalancer/reporting.py
+++ b/ibkr_etf_rebalancer/reporting.py
@@ -9,6 +9,7 @@ from typing import Any, Iterable, Mapping, TYPE_CHECKING
 import pandas as pd
 
 from .rebalance_engine import generate_orders
+from .util import to_bps
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from .ibkr_provider import Fill
@@ -47,7 +48,7 @@ def _build_pre_trade_dataframe(
                 "symbol": symbol,
                 "target_pct": target * 100,
                 "current_pct": current_pct * 100,
-                "drift_bps": diff * 10_000,
+                "drift_bps": to_bps(diff),
                 "price": price,
                 "dollar_delta": dollar_delta,
                 "share_delta": share_delta,
@@ -251,7 +252,7 @@ def generate_post_trade_report(
         current_shares = current.get(symbol, 0.0) * total_equity / prices[symbol]
         residual_shares = current_shares + qty
         residual_pct = residual_shares * prices[symbol] / total_equity
-        residual_drift = (targets.get(symbol, 0.0) - residual_pct) * 10_000
+        residual_drift = to_bps(targets.get(symbol, 0.0) - residual_pct)
 
         rows.append(
             {

--- a/ibkr_etf_rebalancer/util.py
+++ b/ibkr_etf_rebalancer/util.py
@@ -1,3 +1,34 @@
-"""Util module."""
+"""Miscellaneous utility helpers.
 
-# TODO: implement util
+This module currently provides small helper functions that are used across the
+code base.  Keeping them here avoids sprinkling ``10_000`` constants for basis
+point conversions throughout the project which in turn helps maintain
+consistency when dealing with sizing and reporting logic.
+"""
+
+from __future__ import annotations
+
+__all__ = ["to_bps", "from_bps"]
+
+
+def to_bps(fraction: float) -> float:
+    """Convert *fraction* to basis points.
+
+    Examples
+    --------
+    ``0.0125`` (1.25%) becomes ``125`` basis points.
+    """
+
+    return fraction * 10_000
+
+
+def from_bps(bps: float) -> float:
+    """Convert *bps* (basis points) to a fractional value.
+
+    Examples
+    --------
+    ``125`` basis points becomes ``0.0125`` (1.25%).
+    """
+
+    return bps / 10_000
+

--- a/tests/test_fx_engine.py
+++ b/tests/test_fx_engine.py
@@ -6,6 +6,7 @@ from ibkr_etf_rebalancer.config import FXConfig, PricingConfig
 from ibkr_etf_rebalancer.fx_engine import plan_fx_if_needed
 from ibkr_etf_rebalancer.rebalance_engine import plan_rebalance_with_fx
 from ibkr_etf_rebalancer.pricing import Quote
+from ibkr_etf_rebalancer.util import from_bps
 
 
 @pytest.fixture
@@ -54,7 +55,7 @@ def test_buffer_applied_to_notional(fresh_quote: Quote, fx_cfg: FXConfig) -> Non
         fx_quote=fresh_quote,
         cfg=fx_cfg,
     )
-    expected = shortfall * (1 + fx_cfg.fx_buffer_bps / 10_000)
+    expected = shortfall * (1 + from_bps(fx_cfg.fx_buffer_bps))
     assert plan.usd_notional == pytest.approx(expected)
 
 
@@ -131,7 +132,7 @@ def test_market_rounding(fx_cfg: FXConfig) -> None:
         cfg=fx_cfg,
     )
     assert plan.est_rate == pytest.approx(1.2347)
-    expected = round(1_234.56 * (1 + fx_cfg.fx_buffer_bps / 10_000), 2)
+    expected = round(1_234.56 * (1 + from_bps(fx_cfg.fx_buffer_bps)), 2)
     assert plan.usd_notional == pytest.approx(expected)
     assert plan.qty == pytest.approx(expected)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,14 @@
+"""Tests for generic utility helpers."""
+
+from ibkr_etf_rebalancer.util import from_bps, to_bps
+
+
+def test_to_bps_and_back() -> None:
+    value = 0.0125  # 1.25%
+    bps = to_bps(value)
+    assert bps == 125.0
+    assert from_bps(bps) == value
+
+
+def test_from_bps_negative() -> None:
+    assert from_bps(-50) == -0.005


### PR DESCRIPTION
## Summary
- add helpers for converting to/from basis points
- refactor pricing, FX planning, rebalancing, and reporting to use the helpers
- add unit tests for the helpers

## Testing
- `pytest`

Supports [SRS AC5] and [SRS AC8].

------
https://chatgpt.com/codex/tasks/task_e_68b14407efe48320884daf74f20c20f7