### PR TITLE
feat(util): add percent conversion helpers

### DIFF
--- a/ibkr_etf_rebalancer/util.py
+++ b/ibkr_etf_rebalancer/util.py
@@ -8,7 +8,13 @@ consistency when dealing with sizing and reporting logic.
 
 from __future__ import annotations
 
-__all__ = ["to_bps", "from_bps", "clamp"]
+__all__ = [
+    "to_bps",
+    "from_bps",
+    "to_percent",
+    "from_percent",
+    "clamp",
+]
 
 
 def to_bps(fraction: float) -> float:
@@ -31,6 +37,28 @@ def from_bps(bps: float) -> float:
     """
 
     return bps / 10_000
+
+
+def to_percent(fraction: float) -> float:
+    """Convert *fraction* to a percentage.
+
+    Examples
+    --------
+    ``0.0125`` becomes ``1.25`` percent.
+    """
+
+    return fraction * 100
+
+
+def from_percent(percent: float) -> float:
+    """Convert *percent* to a fractional value.
+
+    Examples
+    --------
+    ``1.25`` percent becomes ``0.0125``.
+    """
+
+    return percent / 100
 
 
 def clamp(value: float, lower: float | None = None, upper: float | None = None) -> float:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,7 +2,13 @@
 
 import pytest
 
-from ibkr_etf_rebalancer.util import from_bps, to_bps, clamp
+from ibkr_etf_rebalancer.util import (
+    from_bps,
+    from_percent,
+    to_bps,
+    to_percent,
+    clamp,
+)
 
 
 def test_to_bps_and_back() -> None:
@@ -12,8 +18,19 @@ def test_to_bps_and_back() -> None:
     assert from_bps(bps) == value
 
 
+def test_to_percent_and_back() -> None:
+    value = 0.0125  # 1.25%
+    percent = to_percent(value)
+    assert percent == 1.25
+    assert from_percent(percent) == value
+
+
 def test_from_bps_negative() -> None:
     assert from_bps(-50) == -0.005
+
+
+def test_from_percent_negative() -> None:
+    assert from_percent(-1.5) == -0.015
 
 
 def test_clamp_basic() -> None:


### PR DESCRIPTION
## Summary
- add `to_percent` and `from_percent` helpers for converting between fractions and percentages
- cover percent helpers with new tests

## Testing
- `pre-commit run --files ibkr_etf_rebalancer/util.py tests/test_util.py`
- `coverage run --source ibkr_etf_rebalancer -m pytest`
- `coverage report`


------
https://chatgpt.com/codex/tasks/task_e_68b1cbe8a014832095de263860accb42