### PR TITLE
chore: remove yaml type ignore

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,4 @@ repos:
           - hypothesis           # tests use hypothesis
           - freezegun            # tests import freezegun
           - typer                # CLI utilities
+          - types-PyYAML         # yaml typing

--- a/tests/e2e/scenario.py
+++ b/tests/e2e/scenario.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterator
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 from freezegun import freeze_time
 from pydantic import BaseModel, Field
 


### PR DESCRIPTION
## Summary
- remove type ignore comment from end-to-end scenario helper
- ensure mypy pre-commit hook provides YAML typing stubs

## Testing
- `pre-commit run --files tests/e2e/scenario.py`
- `mypy --install-types --non-interactive .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1d6011404832089beb21151f1133a