### PR TITLE
Add end-to-end scenario fixtures

### DIFF
--- a/tests/e2e/fixtures/fractional_disallowed.yml
+++ b/tests/e2e/fixtures/fractional_disallowed.yml
@@ -1,0 +1,16 @@
+name: Fractional disallowed
+as_of: 2024-01-01T10:00:00Z
+prices:
+  AAA: 100.0
+quotes:
+  AAA:
+    bid: 99.5
+    ask: 100.5
+positions:
+  AAA: 0.0
+cash:
+  USD: 50.0
+config_overrides:
+  rebalance:
+    allow_fractional: false
+    min_order_usd: 0

--- a/tests/e2e/fixtures/fx_then_rebalance.yml
+++ b/tests/e2e/fixtures/fx_then_rebalance.yml
@@ -1,0 +1,25 @@
+name: FX then rebalance
+as_of: 2024-01-01T10:00:00Z
+prices:
+  AAA: 100.0
+  USD.CAD: 1.35
+quotes:
+  AAA:
+    bid: 99.0
+    ask: 101.0
+  USD.CAD:
+    bid: 1.34
+    ask: 1.36
+positions:
+  AAA: 0
+cash:
+  CAD: 1000.0
+  USD: 0.0
+config_overrides:
+  fx:
+    enabled: true
+    base_currency: USD
+    funding_currencies: [CAD]
+    wait_for_fill_seconds: 1
+  rebalance:
+    min_order_usd: 0

--- a/tests/e2e/fixtures/kill_switch_blocks.yml
+++ b/tests/e2e/fixtures/kill_switch_blocks.yml
@@ -1,0 +1,17 @@
+name: Kill switch blocks
+as_of: 2024-01-01T10:00:00Z
+prices:
+  AAA: 100.0
+quotes:
+  AAA:
+    bid: 99.0
+    ask: 101.0
+positions:
+  AAA: 50
+cash:
+  USD: 10000.0
+config_overrides:
+  safety:
+    kill_switch_file: KILL_SWITCH
+  rebalance:
+    min_order_usd: 0

--- a/tests/e2e/fixtures/margin_cash_negative.yml
+++ b/tests/e2e/fixtures/margin_cash_negative.yml
@@ -1,0 +1,21 @@
+name: Margin cash negative
+as_of: 2024-01-01T10:00:00Z
+prices:
+  AAA: 100.0
+  BBB: 50.0
+quotes:
+  AAA:
+    bid: 99.0
+    ask: 101.0
+  BBB:
+    bid: 49.0
+    ask: 51.0
+positions:
+  AAA: 100
+  BBB: 50
+cash:
+  USD: -5000.0
+config_overrides:
+  rebalance:
+    allow_margin: true
+    max_leverage: 1.5

--- a/tests/e2e/fixtures/no_trade_within_band.yml
+++ b/tests/e2e/fixtures/no_trade_within_band.yml
@@ -1,0 +1,21 @@
+name: No trade within band
+as_of: 2024-01-01T10:00:00Z
+prices:
+  AAA: 100.0
+  BBB: 50.0
+quotes:
+  AAA:
+    bid: 99.5
+    ask: 100.5
+  BBB:
+    bid: 49.5
+    ask: 50.5
+positions:
+  AAA: 60
+  BBB: 40
+cash:
+  USD: 10000.0
+config_overrides:
+  rebalance:
+    per_holding_band_bps: 1000
+    min_order_usd: 0

--- a/tests/e2e/fixtures/overweight_sell_only.yml
+++ b/tests/e2e/fixtures/overweight_sell_only.yml
@@ -1,0 +1,21 @@
+name: Overweight sell only
+as_of: 2024-01-01T10:00:00Z
+prices:
+  AAA: 100.0
+  BBB: 50.0
+quotes:
+  AAA:
+    bid: 99.0
+    ask: 101.0
+  BBB:
+    bid: 49.0
+    ask: 51.0
+positions:
+  AAA: 80
+  BBB: 20
+cash:
+  USD: 5000.0
+config_overrides:
+  rebalance:
+    min_order_usd: 0
+    per_holding_band_bps: 0

--- a/tests/e2e/fixtures/pacing_and_timeout.yml
+++ b/tests/e2e/fixtures/pacing_and_timeout.yml
@@ -1,0 +1,22 @@
+name: Pacing and timeout
+as_of: 2024-01-01T10:00:00Z
+prices:
+  AAA: 100.0
+  BBB: 50.0
+quotes:
+  AAA:
+    bid: 99.0
+    ask: 101.0
+  BBB:
+    bid: 49.0
+    ask: 51.0
+positions:
+  AAA: 50
+  BBB: 50
+cash:
+  USD: 10000.0
+config_overrides:
+  rebalance:
+    order_type: MKT
+    min_order_usd: 0
+    prefer_rth: false

--- a/tests/e2e/fixtures/spread_aware_limits.yml
+++ b/tests/e2e/fixtures/spread_aware_limits.yml
@@ -1,0 +1,23 @@
+name: Spread aware limits
+as_of: 2024-01-01T10:00:00Z
+prices:
+  AAA: 100.0
+  BBB: 50.0
+quotes:
+  AAA:
+    bid: 99.0
+    ask: 101.0
+  BBB:
+    bid: 49.0
+    ask: 51.0
+positions:
+  AAA: 50
+  BBB: 50
+cash:
+  USD: 10000.0
+config_overrides:
+  limits:
+    style: spread_aware
+    buy_offset_frac: 0.1
+    sell_offset_frac: 0.1
+    max_offset_bps: 20

--- a/tests/e2e/fixtures/underweights_scaled.yml
+++ b/tests/e2e/fixtures/underweights_scaled.yml
@@ -1,0 +1,21 @@
+name: Underweights scaled
+as_of: 2024-01-01T10:00:00Z
+prices:
+  AAA: 100.0
+  BBB: 50.0
+quotes:
+  AAA:
+    bid: 99.0
+    ask: 101.0
+  BBB:
+    bid: 49.0
+    ask: 51.0
+positions:
+  AAA: 40
+  BBB: 60
+cash:
+  USD: 100.0
+config_overrides:
+  rebalance:
+    min_order_usd: 0
+    cash_buffer_pct: 0

--- a/tests/e2e/fixtures/wide_stale_escalation.yml
+++ b/tests/e2e/fixtures/wide_stale_escalation.yml
@@ -1,0 +1,18 @@
+name: Wide stale escalation
+as_of: 2024-01-01T10:00:00Z
+prices:
+  AAA: 100.0
+quotes:
+  AAA:
+    bid: 90.0
+    ask: 110.0
+positions:
+  AAA: 50
+cash:
+  USD: 10000.0
+config_overrides:
+  limits:
+    style: spread_aware
+    wide_spread_bps: 1
+    stale_quote_seconds: 0
+    escalate_action: market


### PR DESCRIPTION
## Summary
- add YAML fixtures for E2E scenarios: no trade within band, sell-only overweights, scaled underweights, fractional disallowed, margin cash negative, FX then rebalance, spread-aware limits, wide stale escalation, pacing and timeout, and kill switch blocks

## Testing
- `pre-commit run --files tests/e2e/fixtures/no_trade_within_band.yml tests/e2e/fixtures/overweight_sell_only.yml tests/e2e/fixtures/underweights_scaled.yml tests/e2e/fixtures/fractional_disallowed.yml tests/e2e/fixtures/margin_cash_negative.yml tests/e2e/fixtures/fx_then_rebalance.yml tests/e2e/fixtures/spread_aware_limits.yml tests/e2e/fixtures/wide_stale_escalation.yml tests/e2e/fixtures/pacing_and_timeout.yml tests/e2e/fixtures/kill_switch_blocks.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1df0a1f0c832080cfca1ce57924c7