### PR TITLE
docs: add changelog entry for offline scenario runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added Phase 0 review checklist.
 - Added integration test covering FX → SELL → BUY order sequencing with `FakeIB`.
 - Updated pull request description to cite SRS AC5 and AC6 for order building and execution changes.
+- feat(e2e): add offline scenario runner and YAML-driven tests [AC1–AC13]
 
 
 ## Phase 6


### PR DESCRIPTION
## Summary
- document offline scenario runner and YAML-driven tests in changelog

## Testing
- `make lint` *(fails: F841 Local variable `rank_map` is assigned to but never used)*
- `make type` *(fails: Library stubs not installed for `yaml`; Missing type parameters for `dict`)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e6b7ccc48320bb7e64fea22c78ab