### PR TITLE
Add E2E scenario usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ Phase 5 adds provider abstractions (`IBKRProvider`, `FakeIB`, `LiveIB`) and the
 `IBKRQuoteProvider` for market data. These exports support account snapshot
 retrieval and pacing safeguards. [SRS AC3][SRS AC9]
 
+## E2E scenarios
+
+End-to-end scenarios exercise the full workflow using fake brokers and quotes.
+Run a scenario with:
+
+```bash
+python -m ibkr_etf_rebalancer.app scenario tests/e2e/fixtures/no_trade_within_band.yml --paper
+```
+
+This writes pre- and post-trade reports (CSV and Markdown) and an event log to
+the directory configured by `io.report_dir` in the configuration file (default
+`reports/`).
+
 ## Further Documentation
 
 - [System Requirements Specification](srs.md)


### PR DESCRIPTION
## Summary
- document how to run an end-to-end scenario with the CLI
- note that reports and event logs are written under the configured `io.report_dir`

## Testing
- `make lint` *(fails: F841 Local variable `rank_map` is assigned to but never used)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e6ab34108320a0be10d41529b68b