### PR TITLE
feat(e2e): add scenario runner

### DIFF
--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -66,7 +66,8 @@ def run_scenario(scenario: Scenario) -> ScenarioRunResult:
     * Persist the broker event log.
     """
 
-    def _run(cfg: AppConfig) -> ScenarioRunResult:
+    with scenario.frozen_time():
+        cfg: AppConfig = scenario.app_config()
         as_of = scenario.as_of
         stamp = as_of.strftime("%Y%m%dT%H%M%S")
         output_dir = Path(cfg.io.report_dir)
@@ -255,5 +256,3 @@ def run_scenario(scenario: Scenario) -> ScenarioRunResult:
             post_report_md=post_md,
             event_log=event_log_path,
         )
-
-    return scenario.execute(_run)


### PR DESCRIPTION
## Summary
- orchestrate end-to-end scenario execution in frozen time using fakes
- blend targets, compute snapshot, plan rebalance with FX, build/execute orders
- generate pre/post trade reports and persist broker event log

## Testing
- `pre-commit run --files tests/e2e/runner.py`
- `pytest tests/e2e/test_scenarios.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1ea9c512c83209a9497a08ce1dcce