### PR TITLE
feat(cli): add scenario option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added integration test covering FX → SELL → BUY order sequencing with `FakeIB`.
 - Updated pull request description to cite SRS AC5 and AC6 for order building and execution changes.
 - feat(e2e): add offline scenario runner and YAML-driven tests [AC1–AC13]
+- feat(cli): add `--scenario` option to run YAML scenarios with paper mode default and kill-switch checks
 
 
 ## Phase 6

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ python -m ibkr_etf_rebalancer.app pre-trade \
     --output-dir reports
 ```
 
+Global flags control behaviour: `--report-only`, `--dry-run`,
+`--paper/--no-paper` (paper is the default), `--live`, `--yes`, and
+`--scenario PATH` to execute a YAML-defined end-to-end scenario instead of
+loading CSV/INI inputs.
+
 The configuration file can include an `[fx]` section to plan CAD→USD conversions ahead of ETF trades. This feature lets you enable FX planning and set per-order limits and acceptable slippage:
 
 ```ini
@@ -56,7 +61,7 @@ End-to-end scenarios exercise the full workflow using fake brokers and quotes.
 Run a scenario with:
 
 ```bash
-python -m ibkr_etf_rebalancer.app scenario tests/e2e/fixtures/no_trade_within_band.yml --paper
+python -m ibkr_etf_rebalancer.app --scenario tests/e2e/fixtures/no_trade_within_band.yml
 ```
 
 This writes pre- and post-trade reports (CSV and Markdown) and an event log to

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -102,3 +102,18 @@ def test_pre_trade_cli_global_flags(tmp_path: Path, flag: str) -> None:
         )
 
     assert result.exit_code == 0
+
+
+def test_scenario_flag(tmp_path: Path) -> None:
+    """Running with --scenario executes the scenario runner."""
+    fixture = Path(__file__).resolve().parent / "e2e/fixtures/no_trade_within_band.yml"
+    scenario_path = tmp_path / "scenario.yml"
+    scenario_path.write_text(fixture.read_text().replace("min_order_usd: 0", "min_order_usd: 1e-9"))
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(app, ["--yes", "--scenario", str(scenario_path)])
+        assert result.exit_code == 0
+        report_dir = Path("reports")
+        csv = report_dir / "pre_trade_report_20240101T100000.csv"
+        md = report_dir / "pre_trade_report_20240101T100000.md"
+        assert csv.exists()
+        assert md.exists()


### PR DESCRIPTION
## Summary
- allow running YAML scenarios via new `--scenario` CLI option
- default CLI to paper trading and enforce kill switch checks
- document new flag and add regression test

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b1edb076a08320a3644c636e05297b