### PR TITLE
test: verify deterministic e2e scenarios

### DIFF
--- a/tests/e2e/test_scenarios.py
+++ b/tests/e2e/test_scenarios.py
@@ -141,13 +141,20 @@ def test_scenarios(fixture_path: Path) -> None:
             f"{info['symbol']}.{info['currency']}" if info["sec_type"] == "CASH" else info["symbol"]
         )
         quote = scenario.quotes[key]
-        if info["side"] == "BUY":
+        if info["sec_type"] == "CASH":
             if info["limit_price"] is not None:
-                assert info["limit_price"] <= quote.ask + 1e-6
-            rank = 0 if info["sec_type"] == "CASH" else 2
-        else:
+                if info["side"] == "BUY":
+                    assert info["limit_price"] <= quote.ask + 1e-6
+                else:
+                    assert info["limit_price"] >= quote.bid - 1e-6
+            rank = 0
+        elif info["side"] == "SELL":
             if info["limit_price"] is not None:
                 assert info["limit_price"] >= quote.bid - 1e-6
             rank = 1
+        else:
+            if info["limit_price"] is not None:
+                assert info["limit_price"] <= quote.ask + 1e-6
+            rank = 2
         assert rank >= last_rank
         last_rank = rank


### PR DESCRIPTION
## Summary
- parametrize scenario tests over all fixtures and run each twice for deterministic file hashes
- compare scenario outputs to golden CSV/MD with numeric tolerance
- enforce FX -> SELL -> BUY ordering in event logs and validate limit prices

## Testing
- `pytest tests/e2e/test_scenarios.py`

------
https://chatgpt.com/codex/tasks/task_e_68b1f442e32083209642c0ebe8f9ca4f