### PR TITLE
Add reusable scenario data model with validation and time control

### DIFF
--- a/ibkr_etf_rebalancer/app.py
+++ b/ibkr_etf_rebalancer/app.py
@@ -97,7 +97,7 @@ def main(
     # Run a pre-canned scenario and exit when requested.
     if scenario is not None:
         from . import safety
-        from tests.e2e.scenario import load_scenario
+        from ibkr_etf_rebalancer.scenario import load_scenario
         from tests.e2e.runner import run_scenario
 
         sc = load_scenario(scenario)

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -29,7 +29,7 @@ from ibkr_etf_rebalancer.reporting import generate_post_trade_report, generate_p
 from ibkr_etf_rebalancer.target_blender import BlendResult, blend_targets
 from ibkr_etf_rebalancer.util import from_bps
 
-from .scenario import Scenario
+from ibkr_etf_rebalancer.scenario import Scenario
 
 
 @dataclass

--- a/tests/e2e/test_scenarios.py
+++ b/tests/e2e/test_scenarios.py
@@ -8,7 +8,7 @@ from typing import Any
 import pandas as pd
 import pytest
 
-from .scenario import load_scenario
+from ibkr_etf_rebalancer.scenario import load_scenario
 from .runner import run_scenario
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"

--- a/tests/e2e/update_golden.py
+++ b/tests/e2e/update_golden.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .scenario import load_scenario
+from ibkr_etf_rebalancer.scenario import load_scenario
 from .runner import run_scenario
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"


### PR DESCRIPTION
## Summary
- Move scenario helpers into package and expose `Quote` and `Scenario` dataclasses
- Validate scenario files with Pydantic and allow deep-merged config overrides
- Provide `frozen_time()` context manager to freeze scenario time

## Testing
- `pre-commit run --files ibkr_etf_rebalancer/scenario.py tests/e2e/runner.py tests/e2e/test_scenarios.py tests/e2e/update_golden.py ibkr_etf_rebalancer/app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1f783a8308320996e34078deaf637