### PR TITLE
Add scenario runner for end-to-end execution

### DIFF
--- a/ibkr_etf_rebalancer/__init__.py
+++ b/ibkr_etf_rebalancer/__init__.py
@@ -3,6 +3,7 @@
 from .account_state import AccountSnapshot, compute_account_state
 from .ibkr_provider import FakeIB, IBKRProvider, IBKRProviderOptions, LiveIB
 from .pricing import IBKRQuoteProvider
+from .scenario_runner import ScenarioRunResult, run_scenario
 
 __all__ = [
     "AccountSnapshot",
@@ -12,4 +13,6 @@ __all__ = [
     "FakeIB",
     "LiveIB",
     "IBKRQuoteProvider",
+    "run_scenario",
+    "ScenarioRunResult",
 ]

--- a/ibkr_etf_rebalancer/app.py
+++ b/ibkr_etf_rebalancer/app.py
@@ -98,7 +98,7 @@ def main(
     if scenario is not None:
         from . import safety
         from ibkr_etf_rebalancer.scenario import load_scenario
-        from tests.e2e.runner import run_scenario
+        from .scenario_runner import run_scenario
 
         sc = load_scenario(scenario)
         cfg = sc.app_config()

--- a/ibkr_etf_rebalancer/scenario_runner.py
+++ b/ibkr_etf_rebalancer/scenario_runner.py
@@ -5,9 +5,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, cast
 
-from ibkr_etf_rebalancer.account_state import AccountSnapshot, compute_account_state
-from ibkr_etf_rebalancer.config import AppConfig
-from ibkr_etf_rebalancer.ibkr_provider import (
+from .account_state import AccountSnapshot, compute_account_state
+from .config import AppConfig
+from .ibkr_provider import (
     AccountValue,
     Contract,
     FakeIB,
@@ -17,19 +17,18 @@ from ibkr_etf_rebalancer.ibkr_provider import (
     OrderSide,
     Position,
 )
-from ibkr_etf_rebalancer.order_builder import build_fx_order, build_orders
-from ibkr_etf_rebalancer.order_executor import (
+from .order_builder import build_fx_order, build_orders
+from .order_executor import (
     OrderExecutionOptions,
     OrderExecutionResult,
     execute_orders,
 )
-from ibkr_etf_rebalancer.pricing import FakeQuoteProvider, Quote
-from ibkr_etf_rebalancer.rebalance_engine import FxPlan, OrderPlan, plan_rebalance_with_fx
-from ibkr_etf_rebalancer.reporting import generate_post_trade_report, generate_pre_trade_report
-from ibkr_etf_rebalancer.target_blender import BlendResult, blend_targets
-from ibkr_etf_rebalancer.util import from_bps
-
-from ibkr_etf_rebalancer.scenario import Scenario
+from .pricing import FakeQuoteProvider, Quote
+from .rebalance_engine import FxPlan, OrderPlan, plan_rebalance_with_fx
+from .reporting import generate_post_trade_report, generate_pre_trade_report
+from .scenario import Scenario
+from .target_blender import BlendResult, blend_targets
+from .util import from_bps
 
 
 @dataclass

--- a/tests/e2e/test_scenarios.py
+++ b/tests/e2e/test_scenarios.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 
 from ibkr_etf_rebalancer.scenario import load_scenario
-from .runner import run_scenario
+from ibkr_etf_rebalancer.scenario_runner import run_scenario
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
 GOLDEN_DIR = Path(__file__).parent / "golden"

--- a/tests/e2e/update_golden.py
+++ b/tests/e2e/update_golden.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from ibkr_etf_rebalancer.scenario import load_scenario
-from .runner import run_scenario
+from ibkr_etf_rebalancer.scenario_runner import run_scenario
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
 GOLDEN_DIR = Path(__file__).parent / "golden"


### PR DESCRIPTION
## Summary
- provide `run_scenario` utility to drive FakeQuoteProvider/FakeIB flows
- export scenario runner from package and wire CLI to use it
- update end-to-end tests and golden update script

## Testing
- `pre-commit run --files ibkr_etf_rebalancer/scenario_runner.py ibkr_etf_rebalancer/__init__.py ibkr_etf_rebalancer/app.py tests/e2e/test_scenarios.py tests/e2e/update_golden.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b209aabc0c8320ac1d7ab45cd317fb