### PR TITLE
feat: add helper for regenerating e2e golden files

### DIFF
--- a/tests/e2e/update_golden.py
+++ b/tests/e2e/update_golden.py
@@ -1,4 +1,11 @@
 from pathlib import Path
+import sys
+
+# Ensure project root is on the module search path so the script can be executed
+# directly via ``python tests/e2e/update_golden.py``.
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from ibkr_etf_rebalancer.scenario import load_scenario
 from ibkr_etf_rebalancer.scenario_runner import run_scenario


### PR DESCRIPTION
## Summary
- ensure update_golden helper can run directly by adding repo root to sys.path
- regenerate golden test artifacts for all E2E scenarios

## Testing
- `python tests/e2e/update_golden.py`
- `pytest tests/e2e/test_scenarios.py`


------
https://chatgpt.com/codex/tasks/task_e_68b210e6ec6883209f75a64e9be40870