### PR TITLE
Force paper mode for scenario CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Global flags control behaviour: `--report-only`, `--dry-run`,
 `--scenario PATH` to execute a YAML-defined end-to-end scenario instead of
 loading CSV/INI inputs.
 
+Run a full end-to-end scenario which always operates in paper mode:
+
+```bash
+python -m ibkr_etf_rebalancer.app --scenario tests/e2e/fixtures/no_trade_within_band.yml
+```
+
+This bypasses any live broker connectivity and prints the generated report
+paths to standard output.
+
 The configuration file can include an `[fx]` section to plan CAD→USD conversions ahead of ETF trades. This feature lets you enable FX planning and set per-order limits and acceptable slippage:
 
 ```ini

--- a/ibkr_etf_rebalancer/app.py
+++ b/ibkr_etf_rebalancer/app.py
@@ -103,7 +103,10 @@ def main(
         sc = load_scenario(scenario)
         cfg = sc.app_config()
         safety.check_kill_switch(cfg.safety.kill_switch_file)
-        safety.ensure_paper_trading(options.paper, options.live)
+        # Scenarios always run in paper mode using fake providers and should
+        # never attempt a real broker connection. Ignore any user supplied
+        # ``--live`` or ``--no-paper`` flags and force paper trading.
+        safety.ensure_paper_trading(paper=True, live=False)
         if cfg.safety.require_confirm:
             safety.require_confirmation("Proceed with scenario execution?", options.yes)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -117,3 +117,21 @@ def test_scenario_flag(tmp_path: Path) -> None:
         md = report_dir / "pre_trade_report_20240101T100000.md"
         assert csv.exists()
         assert md.exists()
+
+
+@pytest.mark.parametrize("flag", ["--no-paper", "--live"])
+def test_scenario_forces_paper(tmp_path: Path, flag: str) -> None:
+    """Scenario flag should ignore live/paper toggles and still run."""
+    fixture = Path(__file__).resolve().parent / "e2e/fixtures/no_trade_within_band.yml"
+    scenario_path = tmp_path / "scenario.yml"
+    scenario_path.write_text(
+        fixture.read_text().replace("min_order_usd: 0", "min_order_usd: 1e-9")
+    )
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(app, ["--yes", flag, "--scenario", str(scenario_path)])
+        assert result.exit_code == 0
+        report_dir = Path("reports")
+        csv = report_dir / "pre_trade_report_20240101T100000.csv"
+        md = report_dir / "pre_trade_report_20240101T100000.md"
+        assert csv.exists()
+        assert md.exists()


### PR DESCRIPTION
## Summary
- force `--scenario` runs to operate in paper mode only and skip any live connectivity
- document `--scenario` usage in the README
- test that scenario runs ignore `--live` and `--no-paper` flags

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b21a4ad7d48320946f0f83e5e855e2