### PR TITLE
Respect custom limit settings in order builder

### DIFF
--- a/ibkr_etf_rebalancer/scenario_runner.py
+++ b/ibkr_etf_rebalancer/scenario_runner.py
@@ -4,6 +4,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, cast
+from types import SimpleNamespace
 
 from .account_state import AccountSnapshot, compute_account_state
 from .config import AppConfig
@@ -198,10 +199,11 @@ def run_scenario(scenario: Scenario) -> ScenarioRunResult:
         )
 
         order_quotes = {sym: quote_provider.get_quote(sym) for sym in plan.orders}
+        order_cfg = SimpleNamespace(**cfg.rebalance.model_dump(), limits=cfg.limits)
         orders = build_orders(
             plan.orders,
             order_quotes,
-            cfg.rebalance,
+            order_cfg,
             contracts,
             allow_fractional=cfg.rebalance.allow_fractional,
             allow_margin=cfg.rebalance.allow_margin,

--- a/tests/e2e/golden/wide_stale_escalation/event_log_20240101T100000.json
+++ b/tests/e2e/golden/wide_stale_escalation/event_log_20240101T100000.json
@@ -3,7 +3,7 @@
     "ts": "2024-01-01 10:00:00.000001+00:00",
     "type": "placed",
     "order_id": "1",
-    "order": "Order(contract=Contract(symbol='AAA', sec_type='STK', currency='USD', exchange='SMART', con_id=1), side=<OrderSide.BUY: 'BUY'>, quantity=99, order_type=<OrderType.LIMIT: 'LMT'>, tif=<TimeInForce.DAY: 'DAY'>, route=<OrderRoute.SMART: 'SMART'>, limit_price=110.0, rth=<RTH.RTH_ONLY: 1>)"
+    "order": "Order(contract=Contract(symbol='AAA', sec_type='STK', currency='USD', exchange='SMART', con_id=1), side=<OrderSide.BUY: 'BUY'>, quantity=99, order_type=<OrderType.MARKET: 'MKT'>, tif=<TimeInForce.DAY: 'DAY'>, route=<OrderRoute.SMART: 'SMART'>, limit_price=None, rth=<RTH.RTH_ONLY: 1>)"
   },
   {
     "ts": "2024-01-01 10:00:00.000003+00:00",


### PR DESCRIPTION
## Summary
- combine rebalance and limit configs into a SimpleNamespace
- pass combined config to build_orders so spread-aware settings and escalations are honoured
- regenerate wide_stale_escalation golden files

## Testing
- `pre-commit run --files ibkr_etf_rebalancer/scenario_runner.py tests/e2e/golden/wide_stale_escalation/event_log_20240101T100000.json`
- `pytest tests/e2e/test_scenarios.py::test_scenarios -k 'spread_aware_limits or wide_stale_escalation'`

------
https://chatgpt.com/codex/tasks/task_e_68b22644cc2c83209a0a3ae4b98d1577