### PR TITLE
Configure per-scenario pacing limits and assertions

### DIFF
--- a/tests/e2e/fixtures/pacing_and_timeout.yml
+++ b/tests/e2e/fixtures/pacing_and_timeout.yml
@@ -20,3 +20,7 @@ config_overrides:
     order_type: MKT
     min_order_usd: 0
     prefer_rth: false
+  execution:
+    concurrency_cap: 1
+  fake_ib:
+    concurrency_limit: 1

--- a/tests/e2e/golden/pacing_and_timeout/event_log_20240101T100000.json
+++ b/tests/e2e/golden/pacing_and_timeout/event_log_20240101T100000.json
@@ -6,16 +6,16 @@
     "order": "Order(contract=Contract(symbol='BBB', sec_type='STK', currency='USD', exchange='SMART', con_id=1), side=<OrderSide.BUY: 'BUY'>, quantity=66, order_type=<OrderType.MARKET: 'MKT'>, tif=<TimeInForce.DAY: 'DAY'>, route=<OrderRoute.SMART: 'SMART'>, limit_price=None, rth=<RTH.ALL_HOURS: 0>)"
   },
   {
-    "ts": "2024-01-01 10:00:00.000002+00:00",
-    "type": "placed",
-    "order_id": "2",
-    "order": "Order(contract=Contract(symbol='AAA', sec_type='STK', currency='USD', exchange='SMART', con_id=2), side=<OrderSide.BUY: 'BUY'>, quantity=66, order_type=<OrderType.MARKET: 'MKT'>, tif=<TimeInForce.DAY: 'DAY'>, route=<OrderRoute.SMART: 'SMART'>, limit_price=None, rth=<RTH.ALL_HOURS: 0>)"
+    "ts": "2024-01-01 10:00:00.000003+00:00",
+    "type": "filled",
+    "order_id": "1",
+    "fill": "Fill(contract=Contract(symbol='BBB', sec_type='STK', currency='USD', exchange='SMART', con_id=1), side=<OrderSide.BUY: 'BUY'>, quantity=66, price=51.0, timestamp=FakeDatetime(2024, 1, 1, 10, 0, 0, 2, tzinfo=datetime.timezone.utc), order_id='1')"
   },
   {
     "ts": "2024-01-01 10:00:00.000004+00:00",
-    "type": "filled",
-    "order_id": "1",
-    "fill": "Fill(contract=Contract(symbol='BBB', sec_type='STK', currency='USD', exchange='SMART', con_id=1), side=<OrderSide.BUY: 'BUY'>, quantity=66, price=51.0, timestamp=FakeDatetime(2024, 1, 1, 10, 0, 0, 3, tzinfo=datetime.timezone.utc), order_id='1')"
+    "type": "placed",
+    "order_id": "2",
+    "order": "Order(contract=Contract(symbol='AAA', sec_type='STK', currency='USD', exchange='SMART', con_id=2), side=<OrderSide.BUY: 'BUY'>, quantity=66, order_type=<OrderType.MARKET: 'MKT'>, tif=<TimeInForce.DAY: 'DAY'>, route=<OrderRoute.SMART: 'SMART'>, limit_price=None, rth=<RTH.ALL_HOURS: 0>)"
   },
   {
     "ts": "2024-01-01 10:00:00.000006+00:00",

--- a/tests/e2e/test_scenarios.py
+++ b/tests/e2e/test_scenarios.py
@@ -167,6 +167,12 @@ def test_scenarios(fixture_path: Path) -> None:
         if kill_path:
             assert placed == []
             return
+        if result2.execution.timed_out:
+            assert any(e["type"] == "canceled" for e in events)
+        exec_cap = scenario.config_overrides.get("execution", {}).get("concurrency_cap")
+        fake_ib_limit = scenario.config_overrides.get("fake_ib", {}).get("concurrency_limit")
+        if exec_cap == 1 and fake_ib_limit == 1:
+            assert [e["type"] for e in events] == ["placed", "filled", "placed", "filled"]
         last_rank = -1
         for e in placed:
             info = _parse_order(e["order"])


### PR DESCRIPTION
## Summary
- allow scenario fixtures to override FakeIB `concurrency_limit` and execution `concurrency_cap`
- verify pacing/timeout behaviour in e2e scenarios and record sequential event log

## Testing
- `python tests/e2e/update_golden.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2281f8a4c8320920ff3516dd0de0d