### PR TITLE
Track order limit prices and report slippage

### DIFF
--- a/ibkr_etf_rebalancer/order_executor.py
+++ b/ibkr_etf_rebalancer/order_executor.py
@@ -103,6 +103,8 @@ class OrderExecutionResult:
         Fills returned by the provider.
     canceled:
         Orders that were canceled due to timeout or partial fills.
+    limit_prices:
+        Mapping of order IDs to their submitted limit prices.
     timed_out:
         ``True`` if any batch timed out while waiting for fills.
     sell_proceeds:
@@ -112,6 +114,7 @@ class OrderExecutionResult:
     fills: list[Fill]
     canceled: list[Order]
     order_ids: dict[Order, str] = field(default_factory=dict)
+    limit_prices: dict[str, float | None] = field(default_factory=dict)
     timed_out: bool = False
     sell_proceeds: float = 0.0
 
@@ -232,6 +235,7 @@ def execute_orders(
                     order_id = ib.place_order(o)
                     order_ids.append(order_id)
                     result.order_ids[o] = order_id
+                    result.limit_prices[order_id] = o.limit_price
                     logger.info(
                         "order_placed",
                         extra={

--- a/ibkr_etf_rebalancer/scenario_runner.py
+++ b/ibkr_etf_rebalancer/scenario_runner.py
@@ -252,6 +252,7 @@ def run_scenario(scenario: Scenario) -> ScenarioRunResult:
                 scenario.prices,
                 snapshot.total_equity,
                 execution.fills,
+                execution.limit_prices,
                 output_dir=output_dir,
                 as_of=as_of,
             ),

--- a/tests/e2e/golden/fractional_disallowed/post_trade_report_20240101T100000.csv
+++ b/tests/e2e/golden/fractional_disallowed/post_trade_report_20240101T100000.csv
@@ -1,2 +1,2 @@
-symbol,side,filled_shares,avg_price,notional,residual_drift_bps
-AAA,BUY,1001.0,100.5,100600.5,-9.5
+symbol,side,filled_shares,avg_price,notional,avg_slippage,residual_drift_bps
+AAA,BUY,1001.0,100.5,100600.5,0.0,-9.5

--- a/tests/e2e/golden/fractional_disallowed/post_trade_report_20240101T100000.md
+++ b/tests/e2e/golden/fractional_disallowed/post_trade_report_20240101T100000.md
@@ -1,3 +1,3 @@
-| symbol | side | filled_shares | avg_price | notional | residual_drift_bps |
-| --- | --- | --- | --- | --- | --- |
-| AAA | BUY | 1001.0000 | 100.50 | 100600.50 | -9.50 |
+| symbol | side | filled_shares | avg_price | notional | avg_slippage | residual_drift_bps |
+| --- | --- | --- | --- | --- | --- | --- |
+| AAA | BUY | 1001.0000 | 100.50 | 100600.50 | 0.00 | -9.50 |

--- a/tests/e2e/golden/fx_then_rebalance/post_trade_report_20240101T100000.csv
+++ b/tests/e2e/golden/fx_then_rebalance/post_trade_report_20240101T100000.csv
@@ -1,2 +1,2 @@
-symbol,side,filled_shares,avg_price,notional,residual_drift_bps
-AAA,BUY,8.0,101.0,808.0,-800.0
+symbol,side,filled_shares,avg_price,notional,avg_slippage,residual_drift_bps
+AAA,BUY,8.0,101.0,808.0,0.0,-800.0

--- a/tests/e2e/golden/fx_then_rebalance/post_trade_report_20240101T100000.md
+++ b/tests/e2e/golden/fx_then_rebalance/post_trade_report_20240101T100000.md
@@ -1,3 +1,3 @@
-| symbol | side | filled_shares | avg_price | notional | residual_drift_bps |
-| --- | --- | --- | --- | --- | --- |
-| AAA | BUY | 8.0000 | 101.00 | 808.00 | -800.00 |
+| symbol | side | filled_shares | avg_price | notional | avg_slippage | residual_drift_bps |
+| --- | --- | --- | --- | --- | --- | --- |
+| AAA | BUY | 8.0000 | 101.00 | 808.00 | 0.00 | -800.00 |

--- a/tests/e2e/golden/margin_cash_negative/post_trade_report_20240101T100000.csv
+++ b/tests/e2e/golden/margin_cash_negative/post_trade_report_20240101T100000.csv
@@ -1,3 +1,3 @@
-symbol,side,filled_shares,avg_price,notional,residual_drift_bps
-BBB,SELL,-20.0,49.0,-980.0,22.08
-AAA,SELL,-40.0,99.0,-3960.0,88.3
+symbol,side,filled_shares,avg_price,notional,avg_slippage,residual_drift_bps
+BBB,SELL,-20.0,49.0,-980.0,0.0,22.08
+AAA,SELL,-40.0,99.0,-3960.0,0.0,88.3

--- a/tests/e2e/golden/margin_cash_negative/post_trade_report_20240101T100000.md
+++ b/tests/e2e/golden/margin_cash_negative/post_trade_report_20240101T100000.md
@@ -1,4 +1,4 @@
-| symbol | side | filled_shares | avg_price | notional | residual_drift_bps |
-| --- | --- | --- | --- | --- | --- |
-| BBB | SELL | -20.0000 | 49.00 | -980.00 | 22.08 |
-| AAA | SELL | -40.0000 | 99.00 | -3960.00 | 88.30 |
+| symbol | side | filled_shares | avg_price | notional | avg_slippage | residual_drift_bps |
+| --- | --- | --- | --- | --- | --- | --- |
+| BBB | SELL | -20.0000 | 49.00 | -980.00 | 0.00 | 22.08 |
+| AAA | SELL | -40.0000 | 99.00 | -3960.00 | 0.00 | 88.30 |

--- a/tests/e2e/golden/overweight_sell_only/post_trade_report_20240101T100000.csv
+++ b/tests/e2e/golden/overweight_sell_only/post_trade_report_20240101T100000.csv
@@ -1,3 +1,3 @@
-symbol,side,filled_shares,avg_price,notional,residual_drift_bps
-BBB,BUY,11.0,51.0,561.0,1.41
-AAA,BUY,43.0,101.0,4343.0,82.69
+symbol,side,filled_shares,avg_price,notional,avg_slippage,residual_drift_bps
+BBB,BUY,11.0,51.0,561.0,0.0,1.41
+AAA,BUY,43.0,101.0,4343.0,0.0,82.69

--- a/tests/e2e/golden/overweight_sell_only/post_trade_report_20240101T100000.md
+++ b/tests/e2e/golden/overweight_sell_only/post_trade_report_20240101T100000.md
@@ -1,4 +1,4 @@
-| symbol | side | filled_shares | avg_price | notional | residual_drift_bps |
-| --- | --- | --- | --- | --- | --- |
-| BBB | BUY | 11.0000 | 51.00 | 561.00 | 1.41 |
-| AAA | BUY | 43.0000 | 101.00 | 4343.00 | 82.69 |
+| symbol | side | filled_shares | avg_price | notional | avg_slippage | residual_drift_bps |
+| --- | --- | --- | --- | --- | --- | --- |
+| BBB | BUY | 11.0000 | 51.00 | 561.00 | 0.00 | 1.41 |
+| AAA | BUY | 43.0000 | 101.00 | 4343.00 | 0.00 | 82.69 |

--- a/tests/e2e/golden/pacing_and_timeout/post_trade_report_20240101T100000.csv
+++ b/tests/e2e/golden/pacing_and_timeout/post_trade_report_20240101T100000.csv
@@ -1,3 +1,3 @@
-symbol,side,filled_shares,avg_price,notional,residual_drift_bps
-BBB,BUY,66.0,51.0,3366.0,10.84
-AAA,BUY,66.0,101.0,6666.0,21.67
+symbol,side,filled_shares,avg_price,notional,avg_slippage,residual_drift_bps
+BBB,BUY,66.0,51.0,3366.0,0.0,10.84
+AAA,BUY,66.0,101.0,6666.0,0.0,21.67

--- a/tests/e2e/golden/pacing_and_timeout/post_trade_report_20240101T100000.md
+++ b/tests/e2e/golden/pacing_and_timeout/post_trade_report_20240101T100000.md
@@ -1,4 +1,4 @@
-| symbol | side | filled_shares | avg_price | notional | residual_drift_bps |
-| --- | --- | --- | --- | --- | --- |
-| BBB | BUY | 66.0000 | 51.00 | 3366.00 | 10.84 |
-| AAA | BUY | 66.0000 | 101.00 | 6666.00 | 21.67 |
+| symbol | side | filled_shares | avg_price | notional | avg_slippage | residual_drift_bps |
+| --- | --- | --- | --- | --- | --- | --- |
+| BBB | BUY | 66.0000 | 51.00 | 3366.00 | 0.00 | 10.84 |
+| AAA | BUY | 66.0000 | 101.00 | 6666.00 | 0.00 | 21.67 |

--- a/tests/e2e/golden/spread_aware_limits/post_trade_report_20240101T100000.csv
+++ b/tests/e2e/golden/spread_aware_limits/post_trade_report_20240101T100000.csv
@@ -1,3 +1,3 @@
-symbol,side,filled_shares,avg_price,notional,residual_drift_bps
-BBB,BUY,66.0,51.0,3366.0,10.84
-AAA,BUY,66.0,101.0,6666.0,21.67
+symbol,side,filled_shares,avg_price,notional,avg_slippage,residual_drift_bps
+BBB,BUY,66.0,51.0,3366.0,0.0,10.84
+AAA,BUY,66.0,101.0,6666.0,0.0,21.67

--- a/tests/e2e/golden/spread_aware_limits/post_trade_report_20240101T100000.md
+++ b/tests/e2e/golden/spread_aware_limits/post_trade_report_20240101T100000.md
@@ -1,4 +1,4 @@
-| symbol | side | filled_shares | avg_price | notional | residual_drift_bps |
-| --- | --- | --- | --- | --- | --- |
-| BBB | BUY | 66.0000 | 51.00 | 3366.00 | 10.84 |
-| AAA | BUY | 66.0000 | 101.00 | 6666.00 | 21.67 |
+| symbol | side | filled_shares | avg_price | notional | avg_slippage | residual_drift_bps |
+| --- | --- | --- | --- | --- | --- | --- |
+| BBB | BUY | 66.0000 | 51.00 | 3366.00 | 0.00 | 10.84 |
+| AAA | BUY | 66.0000 | 101.00 | 6666.00 | 0.00 | 21.67 |

--- a/tests/e2e/golden/underweights_scaled/post_trade_report_20240101T100000.csv
+++ b/tests/e2e/golden/underweights_scaled/post_trade_report_20240101T100000.csv
@@ -1,3 +1,3 @@
-symbol,side,filled_shares,avg_price,notional,residual_drift_bps
-BBB,BUY,1.0,51.0,51.0,-10.06
-AAA,BUY,1.0,101.0,101.0,-60.36
+symbol,side,filled_shares,avg_price,notional,avg_slippage,residual_drift_bps
+BBB,BUY,1.0,51.0,51.0,0.0,-10.06
+AAA,BUY,1.0,101.0,101.0,0.0,-60.36

--- a/tests/e2e/golden/underweights_scaled/post_trade_report_20240101T100000.md
+++ b/tests/e2e/golden/underweights_scaled/post_trade_report_20240101T100000.md
@@ -1,4 +1,4 @@
-| symbol | side | filled_shares | avg_price | notional | residual_drift_bps |
-| --- | --- | --- | --- | --- | --- |
-| BBB | BUY | 1.0000 | 51.00 | 51.00 | -10.06 |
-| AAA | BUY | 1.0000 | 101.00 | 101.00 | -60.36 |
+| symbol | side | filled_shares | avg_price | notional | avg_slippage | residual_drift_bps |
+| --- | --- | --- | --- | --- | --- | --- |
+| BBB | BUY | 1.0000 | 51.00 | 51.00 | 0.00 | -10.06 |
+| AAA | BUY | 1.0000 | 101.00 | 101.00 | 0.00 | -60.36 |

--- a/tests/e2e/golden/wide_stale_escalation/post_trade_report_20240101T100000.csv
+++ b/tests/e2e/golden/wide_stale_escalation/post_trade_report_20240101T100000.csv
@@ -1,2 +1,2 @@
-symbol,side,filled_shares,avg_price,notional,residual_drift_bps
-AAA,BUY,99.0,110.0,10890.0,44.3
+symbol,side,filled_shares,avg_price,notional,avg_slippage,residual_drift_bps
+AAA,BUY,99.0,110.0,10890.0,0.0,44.3

--- a/tests/e2e/golden/wide_stale_escalation/post_trade_report_20240101T100000.md
+++ b/tests/e2e/golden/wide_stale_escalation/post_trade_report_20240101T100000.md
@@ -1,3 +1,3 @@
-| symbol | side | filled_shares | avg_price | notional | residual_drift_bps |
-| --- | --- | --- | --- | --- | --- |
-| AAA | BUY | 99.0000 | 110.00 | 10890.00 | 44.30 |
+| symbol | side | filled_shares | avg_price | notional | avg_slippage | residual_drift_bps |
+| --- | --- | --- | --- | --- | --- | --- |
+| AAA | BUY | 99.0000 | 110.00 | 10890.00 | 0.00 | 44.30 |

--- a/tests/golden/post_trade_report.csv
+++ b/tests/golden/post_trade_report.csv
@@ -1,3 +1,3 @@
-symbol,side,filled_shares,avg_price,notional,residual_drift_bps
-AAA,BUY,100.0,10.0,1000.0,900.0
-BBB,SELL,-50.0,20.0,-1000.0,-900.0
+symbol,side,filled_shares,avg_price,notional,avg_slippage,residual_drift_bps
+AAA,BUY,100.0,10.0,1000.0,0.5,900.0
+BBB,SELL,-50.0,20.0,-1000.0,-0.5,-900.0

--- a/tests/golden/post_trade_report.md
+++ b/tests/golden/post_trade_report.md
@@ -1,4 +1,4 @@
-| symbol | side | filled_shares | avg_price | notional | residual_drift_bps |
-| --- | --- | --- | --- | --- | --- |
-| AAA | BUY | 100.0000 | 10.00 | 1000.00 | 900.00 |
-| BBB | SELL | -50.0000 | 20.00 | -1000.00 | -900.00 |
+| symbol | side | filled_shares | avg_price | notional | avg_slippage | residual_drift_bps |
+| --- | --- | --- | --- | --- | --- | --- |
+| AAA | BUY | 100.0000 | 10.00 | 1000.00 | 0.50 | 900.00 |
+| BBB | SELL | -50.0000 | 20.00 | -1000.00 | -0.50 | -900.00 |

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -58,8 +58,12 @@ def test_post_trade_report(tmp_path):
     prices = {"AAA": 10.0, "BBB": 20.0}
 
     fills = [
-        Fill(contract=Contract("AAA"), side=OrderSide.BUY, quantity=100.0, price=10.0, order_id="1"),
-        Fill(contract=Contract("BBB"), side=OrderSide.SELL, quantity=50.0, price=20.0, order_id="2"),
+        Fill(
+            contract=Contract("AAA"), side=OrderSide.BUY, quantity=100.0, price=10.0, order_id="1"
+        ),
+        Fill(
+            contract=Contract("BBB"), side=OrderSide.SELL, quantity=50.0, price=20.0, order_id="2"
+        ),
     ]
     limits = {"1": 9.5, "2": 19.5}
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -58,9 +58,10 @@ def test_post_trade_report(tmp_path):
     prices = {"AAA": 10.0, "BBB": 20.0}
 
     fills = [
-        Fill(contract=Contract("AAA"), side=OrderSide.BUY, quantity=100.0, price=10.0),
-        Fill(contract=Contract("BBB"), side=OrderSide.SELL, quantity=50.0, price=20.0),
+        Fill(contract=Contract("AAA"), side=OrderSide.BUY, quantity=100.0, price=10.0, order_id="1"),
+        Fill(contract=Contract("BBB"), side=OrderSide.SELL, quantity=50.0, price=20.0, order_id="2"),
     ]
+    limits = {"1": 9.5, "2": 19.5}
 
     with freeze_time("2024-01-01 12:00:00"):
         df, csv_path, md_path = generate_post_trade_report(
@@ -69,6 +70,7 @@ def test_post_trade_report(tmp_path):
             prices,
             100_000.0,
             fills,
+            limits,
             output_dir=tmp_path,
         )
 
@@ -78,6 +80,7 @@ def test_post_trade_report(tmp_path):
         "filled_shares",
         "avg_price",
         "notional",
+        "avg_slippage",
         "residual_drift_bps",
     ]
     assert list(df.columns) == expected_cols
@@ -87,6 +90,8 @@ def test_post_trade_report(tmp_path):
     assert df["notional"].sum() == pytest.approx(0.0)
     assert df.loc[df["symbol"] == "AAA", "residual_drift_bps"].iloc[0] == pytest.approx(900.0)
     assert df.loc[df["symbol"] == "BBB", "residual_drift_bps"].iloc[0] == pytest.approx(-900.0)
+    assert df.loc[df["symbol"] == "AAA", "avg_slippage"].iloc[0] == pytest.approx(0.5)
+    assert df.loc[df["symbol"] == "BBB", "avg_slippage"].iloc[0] == pytest.approx(-0.5)
 
     golden_csv = Path("tests/golden/post_trade_report.csv").read_text()
     golden_md = Path("tests/golden/post_trade_report.md").read_text()


### PR DESCRIPTION
## Summary
- retain each order's limit price in `OrderExecutionResult`
- compute slippage in `generate_post_trade_report` and expose as `avg_slippage`
- update scenario runner, tests, and goldens for new slippage column

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2337eba4c8320bfd1a1d9e4bc496d