### PR TITLE
Add snapshot price fallback scenario

### DIFF
--- a/ibkr_etf_rebalancer/scenario.py
+++ b/ibkr_etf_rebalancer/scenario.py
@@ -33,8 +33,8 @@ class Quote:
         Best ask price in the instrument's quote currency.
     """
 
-    bid: float
-    ask: float
+    bid: float | None = None
+    ask: float | None = None
 
 
 @dataclass
@@ -95,8 +95,8 @@ class Scenario:
 
 
 class _QuoteModel(BaseModel):
-    bid: float
-    ask: float
+    bid: float | None = None
+    ask: float | None = None
 
 
 class _ScenarioModel(BaseModel):

--- a/ibkr_etf_rebalancer/scenario_runner.py
+++ b/ibkr_etf_rebalancer/scenario_runner.py
@@ -77,10 +77,10 @@ def run_scenario(scenario: Scenario) -> ScenarioRunResult:
         # ------------------------------------------------------------------
         # Quote and contract setup
         quotes: Dict[str, Quote] = {
-            sym: Quote(bid=q.bid, ask=q.ask, ts=as_of, last=scenario.prices.get(sym))
+            sym: Quote(bid=q.bid, ask=q.ask, ts=as_of)
             for sym, q in scenario.quotes.items()
         }
-        quote_provider = FakeQuoteProvider(quotes)
+        quote_provider = FakeQuoteProvider(quotes, snapshots=scenario.prices)
 
         contracts: Dict[str, Contract] = {}
         ib_quotes: Dict[str, Quote] = {}

--- a/ibkr_etf_rebalancer/scenario_runner.py
+++ b/ibkr_etf_rebalancer/scenario_runner.py
@@ -77,8 +77,7 @@ def run_scenario(scenario: Scenario) -> ScenarioRunResult:
         # ------------------------------------------------------------------
         # Quote and contract setup
         quotes: Dict[str, Quote] = {
-            sym: Quote(bid=q.bid, ask=q.ask, ts=as_of)
-            for sym, q in scenario.quotes.items()
+            sym: Quote(bid=q.bid, ask=q.ask, ts=as_of) for sym, q in scenario.quotes.items()
         }
         quote_provider = FakeQuoteProvider(quotes, snapshots=scenario.prices)
 

--- a/tests/e2e/fixtures/price_source_fallback.yml
+++ b/tests/e2e/fixtures/price_source_fallback.yml
@@ -1,0 +1,26 @@
+name: Price source fallback
+as_of: 2024-01-01T10:00:00Z
+prices:
+  AAA: 100.0
+  USD.CAD: 1.35
+quotes:
+  AAA:
+    bid: 99.0
+    ask: 101.0
+  USD.CAD:
+    bid: null
+    ask: null
+positions:
+  AAA: 0
+cash:
+  CAD: 1000.0
+  USD: 0.0
+config_overrides:
+  fx:
+    enabled: true
+    base_currency: USD
+    funding_currencies: [CAD]
+    wait_for_fill_seconds: 1
+    min_fx_order_usd: 10
+  rebalance:
+    min_order_usd: 0

--- a/tests/e2e/golden/price_source_fallback/event_log_20240101T100000.json
+++ b/tests/e2e/golden/price_source_fallback/event_log_20240101T100000.json
@@ -1,0 +1,26 @@
+[
+  {
+    "ts": "2024-01-01 10:00:00.000001+00:00",
+    "type": "placed",
+    "order_id": "1",
+    "order": "Order(contract=Contract(symbol='USD', sec_type='CASH', currency='CAD', exchange='IDEALPRO', con_id=1), side=<OrderSide.BUY: 'BUY'>, quantity=59.38, order_type=<OrderType.MARKET: 'MKT'>, tif=<TimeInForce.DAY: 'DAY'>, route=<OrderRoute.SMART: 'SMART'>, limit_price=None, rth=<RTH.RTH_ONLY: 1>)"
+  },
+  {
+    "ts": "2024-01-01 10:00:00.000002+00:00",
+    "type": "canceled",
+    "order_id": "1",
+    "order": "Order(contract=Contract(symbol='USD', sec_type='CASH', currency='CAD', exchange='IDEALPRO', con_id=1), side=<OrderSide.BUY: 'BUY'>, quantity=59.38, order_type=<OrderType.MARKET: 'MKT'>, tif=<TimeInForce.DAY: 'DAY'>, route=<OrderRoute.SMART: 'SMART'>, limit_price=None, rth=<RTH.RTH_ONLY: 1>)"
+  },
+  {
+    "ts": "2024-01-01 10:00:00.000003+00:00",
+    "type": "placed",
+    "order_id": "2",
+    "order": "Order(contract=Contract(symbol='AAA', sec_type='STK', currency='USD', exchange='SMART', con_id=2), side=<OrderSide.BUY: 'BUY'>, quantity=8, order_type=<OrderType.LIMIT: 'LMT'>, tif=<TimeInForce.DAY: 'DAY'>, route=<OrderRoute.SMART: 'SMART'>, limit_price=101.0, rth=<RTH.RTH_ONLY: 1>)"
+  },
+  {
+    "ts": "2024-01-01 10:00:00.000005+00:00",
+    "type": "filled",
+    "order_id": "2",
+    "fill": "Fill(contract=Contract(symbol='AAA', sec_type='STK', currency='USD', exchange='SMART', con_id=2), side=<OrderSide.BUY: 'BUY'>, quantity=8, price=101.0, timestamp=FakeDatetime(2024, 1, 1, 10, 0, 0, 4, tzinfo=datetime.timezone.utc), order_id='2')"
+  }
+]

--- a/tests/e2e/golden/price_source_fallback/post_trade_report_20240101T100000.csv
+++ b/tests/e2e/golden/price_source_fallback/post_trade_report_20240101T100000.csv
@@ -1,0 +1,2 @@
+symbol,side,filled_shares,avg_price,notional,avg_slippage,residual_drift_bps
+AAA,BUY,8.0,101.0,808.0,0.0,-800.0

--- a/tests/e2e/golden/price_source_fallback/post_trade_report_20240101T100000.md
+++ b/tests/e2e/golden/price_source_fallback/post_trade_report_20240101T100000.md
@@ -1,0 +1,3 @@
+| symbol | side | filled_shares | avg_price | notional | avg_slippage | residual_drift_bps |
+| --- | --- | --- | --- | --- | --- | --- |
+| AAA | BUY | 8.0000 | 101.00 | 808.00 | 0.00 | -800.00 |

--- a/tests/e2e/golden/price_source_fallback/pre_trade_report_20240101T100000.csv
+++ b/tests/e2e/golden/price_source_fallback/pre_trade_report_20240101T100000.csv
@@ -1,0 +1,8 @@
+NetLiq,740.74
+Cash CAD,1000.00
+Cash USD,740.74
+Cash Buffer,7.41
+
+symbol,target_pct,current_pct,drift_bps,price,dollar_delta,share_delta,side,est_notional,reason
+AAA,100.0,0.0,10000.0,100.0,740.74,7.4074,BUY,740.74,
+TOTAL,100.0,0.0,10000.0,,740.74,,,740.74,

--- a/tests/e2e/golden/price_source_fallback/pre_trade_report_20240101T100000.md
+++ b/tests/e2e/golden/price_source_fallback/pre_trade_report_20240101T100000.md
@@ -1,0 +1,9 @@
+NetLiq: 740.74
+Cash CAD: 1000.00
+Cash USD: 740.74
+Cash Buffer: 7.41
+
+| symbol | target_pct | current_pct | drift_bps | price | dollar_delta | share_delta | side | est_notional | reason |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| AAA | 100.00 | 0.00 | 10000.00 | 100.00 | 740.74 | 7.4074 | BUY | 740.74 |  |
+| TOTAL | 100.00 | 0.00 | 10000.00 |  | 740.74 |  |  | 740.74 |  |

--- a/tests/e2e/test_scenarios.py
+++ b/tests/e2e/test_scenarios.py
@@ -170,6 +170,10 @@ def test_scenarios(fixture_path: Path) -> None:
         if fixture_path.stem == "no_trade_within_band":
             assert events == []
             assert placed == []
+        if fixture_path.stem == "price_source_fallback":
+            assert result2.fx_plan.est_rate == pytest.approx(
+                scenario.prices["USD.CAD"]
+            )
         if kill_path:
             assert placed == []
             return

--- a/tests/e2e/test_scenarios.py
+++ b/tests/e2e/test_scenarios.py
@@ -171,9 +171,7 @@ def test_scenarios(fixture_path: Path) -> None:
             assert events == []
             assert placed == []
         if fixture_path.stem == "price_source_fallback":
-            assert result2.fx_plan.est_rate == pytest.approx(
-                scenario.prices["USD.CAD"]
-            )
+            assert result2.fx_plan.est_rate == pytest.approx(scenario.prices["USD.CAD"])
         if kill_path:
             assert placed == []
             return


### PR DESCRIPTION
## Summary
- allow scenarios to omit bid/ask quotes and supply snapshot prices
- add price_source_fallback e2e fixture and golden outputs
- assert scenario runner uses snapshot price when quotes are missing

## Testing
- `pytest tests/e2e/test_scenarios.py -q`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b23ad3be6083209234053d224c105d