### PR TITLE
fix: ensure quote price defined for limit comparisons

### DIFF
--- a/tests/e2e/test_scenarios.py
+++ b/tests/e2e/test_scenarios.py
@@ -195,16 +195,20 @@ def test_scenarios(fixture_path: Path) -> None:
             if info["sec_type"] == "CASH":
                 if info["limit_price"] is not None:
                     if info["side"] == "BUY":
+                        assert quote.ask is not None
                         assert info["limit_price"] <= quote.ask + 1e-6
                     else:
+                        assert quote.bid is not None
                         assert info["limit_price"] >= quote.bid - 1e-6
                 rank = 0
             elif info["side"] == "SELL":
                 if info["limit_price"] is not None:
+                    assert quote.bid is not None
                     assert info["limit_price"] >= quote.bid - 1e-6
                 rank = 1
             else:
                 if info["limit_price"] is not None:
+                    assert quote.ask is not None
                     assert info["limit_price"] <= quote.ask + 1e-6
                 rank = 2
             assert rank >= last_rank


### PR DESCRIPTION
## Summary
- guard against None quote prices before performing limit price comparisons in tests

## Testing
- `pre-commit run --files tests/e2e/test_scenarios.py`

------
https://chatgpt.com/codex/tasks/task_e_68b23f20e7a88320bacca0786dc704ed