### PR TITLE
Add diff coverage check to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -23,4 +25,7 @@ jobs:
       - name: Type check
         run: mypy --install-types --non-interactive .
       - name: Tests
-        run: pytest
+        run: |
+          coverage run -m pytest
+          coverage xml
+          diff-cover coverage.xml --include tests --fail-under=90

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,10 +7,12 @@ pytest-asyncio
 hypothesis
 freezegun
 pyyaml
+coverage
+diff-cover
 
 # app libs
 pandas
-pandas-stubs         
+pandas-stubs
 pydantic
 typer
 ib_async


### PR DESCRIPTION
## Summary
- add coverage and diff-cover tooling
- fail CI if diff coverage for changed harness code falls below 90%

## Testing
- `ruff check .`
- `black --check .`
- `mypy --install-types --non-interactive .`
- `coverage run -m pytest`
- `coverage xml`
- `diff-cover coverage.xml --include tests --fail-under=90 --compare-branch HEAD^`


------
https://chatgpt.com/codex/tasks/task_e_68b24767741c83208e2de64da625d86b