### PR TITLE
Fix model validator signature in scenario helper

### DIFF
--- a/ibkr_etf_rebalancer/scenario.py
+++ b/ibkr_etf_rebalancer/scenario.py
@@ -119,10 +119,10 @@ class _ScenarioModel(BaseModel):
     config_overrides: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
 
     @model_validator(mode="after")
-    def _check_targets(cls, data: "_ScenarioModel") -> "_ScenarioModel":
-        if data.target_weights and data.portfolios:
+    def _check_targets(self) -> "_ScenarioModel":
+        if self.target_weights and self.portfolios:
             raise ValueError("specify either target_weights or portfolios, not both")
-        return data
+        return self
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- correct `_ScenarioModel` validator to use instance-based signature

## Testing
- `pre-commit run --files ibkr_etf_rebalancer/scenario.py`
- `mypy --install-types --non-interactive .`


------
https://chatgpt.com/codex/tasks/task_e_68b24fbe593883208a82f48968ff3a49