### PR TITLE
feat: support partial fills in FakeIB

### DIFF
--- a/ibkr_etf_rebalancer/scenario_runner.py
+++ b/ibkr_etf_rebalancer/scenario_runner.py
@@ -120,6 +120,7 @@ def run_scenario(scenario: Scenario) -> ScenarioRunResult:
             account_values=account_values,
             positions=positions,
             concurrency_limit=fake_ib_cfg.get("concurrency_limit"),
+            fill_fractions=fake_ib_cfg.get("fill_fractions"),
         )
 
         # ------------------------------------------------------------------

--- a/tests/e2e/fixtures/partial_fill.yml
+++ b/tests/e2e/fixtures/partial_fill.yml
@@ -1,0 +1,23 @@
+name: Partial fill
+as_of: 2024-01-01T10:00:00Z
+prices:
+  AAA: 100.0
+quotes:
+  AAA:
+    bid: 99.0
+    ask: 101.0
+positions:
+  AAA: 10
+cash:
+  USD: 0.0
+target_weights:
+  AAA: 0.0
+  CASH: 1.0
+config_overrides:
+  rebalance:
+    min_order_usd: 0
+    prefer_rth: false
+    order_type: MKT
+  fake_ib:
+    fill_fractions:
+      AAA: 0.5

--- a/tests/e2e/golden/partial_fill/event_log_20240101T100000.json
+++ b/tests/e2e/golden/partial_fill/event_log_20240101T100000.json
@@ -1,0 +1,20 @@
+[
+  {
+    "ts": "2024-01-01 10:00:00.000001+00:00",
+    "type": "placed",
+    "order_id": "1",
+    "order": "Order(contract=Contract(symbol='AAA', sec_type='STK', currency='USD', exchange='SMART', con_id=1), side=<OrderSide.SELL: 'SELL'>, quantity=10, order_type=<OrderType.MARKET: 'MKT'>, tif=<TimeInForce.DAY: 'DAY'>, route=<OrderRoute.SMART: 'SMART'>, limit_price=None, rth=<RTH.ALL_HOURS: 0>)"
+  },
+  {
+    "ts": "2024-01-01 10:00:00.000003+00:00",
+    "type": "filled",
+    "order_id": "1",
+    "fill": "Fill(contract=Contract(symbol='AAA', sec_type='STK', currency='USD', exchange='SMART', con_id=1), side=<OrderSide.SELL: 'SELL'>, quantity=5.0, price=99.0, timestamp=FakeDatetime(2024, 1, 1, 10, 0, 0, 2, tzinfo=datetime.timezone.utc), order_id=None)"
+  },
+  {
+    "ts": "2024-01-01 10:00:00.000004+00:00",
+    "type": "canceled",
+    "order_id": "1",
+    "order": "Order(contract=Contract(symbol='AAA', sec_type='STK', currency='USD', exchange='SMART', con_id=1), side=<OrderSide.SELL: 'SELL'>, quantity=5.0, order_type=<OrderType.MARKET: 'MKT'>, tif=<TimeInForce.DAY: 'DAY'>, route=<OrderRoute.SMART: 'SMART'>, limit_price=None, rth=<RTH.ALL_HOURS: 0>)"
+  }
+]

--- a/tests/e2e/golden/partial_fill/post_trade_report_20240101T100000.csv
+++ b/tests/e2e/golden/partial_fill/post_trade_report_20240101T100000.csv
@@ -1,0 +1,2 @@
+symbol,side,filled_shares,avg_price,notional,avg_slippage,residual_drift_bps
+AAA,SELL,-5.0,99.0,-495.0,0.0,-5000.0

--- a/tests/e2e/golden/partial_fill/post_trade_report_20240101T100000.md
+++ b/tests/e2e/golden/partial_fill/post_trade_report_20240101T100000.md
@@ -1,0 +1,3 @@
+| symbol | side | filled_shares | avg_price | notional | avg_slippage | residual_drift_bps |
+| --- | --- | --- | --- | --- | --- | --- |
+| AAA | SELL | -5.0000 | 99.00 | -495.00 | 0.00 | -5000.00 |

--- a/tests/e2e/golden/partial_fill/pre_trade_report_20240101T100000.csv
+++ b/tests/e2e/golden/partial_fill/pre_trade_report_20240101T100000.csv
@@ -1,0 +1,7 @@
+NetLiq,1000.00
+Cash USD,0.00
+Cash Buffer,0.00
+
+symbol,target_pct,current_pct,drift_bps,price,dollar_delta,share_delta,side,est_notional,reason
+AAA,0.0,100.0,-10000.0,100.0,-1000.0,-10.0,SELL,-1000.0,
+TOTAL,0.0,100.0,-10000.0,,-1000.0,,,-1000.0,

--- a/tests/e2e/golden/partial_fill/pre_trade_report_20240101T100000.md
+++ b/tests/e2e/golden/partial_fill/pre_trade_report_20240101T100000.md
@@ -1,0 +1,8 @@
+NetLiq: 1000.00
+Cash USD: 0.00
+Cash Buffer: 0.00
+
+| symbol | target_pct | current_pct | drift_bps | price | dollar_delta | share_delta | side | est_notional | reason |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| AAA | 0.00 | 100.00 | -10000.00 | 100.00 | -1000.00 | -10.0000 | SELL | -1000.00 |  |
+| TOTAL | 0.00 | 100.00 | -10000.00 |  | -1000.00 |  |  | -1000.00 |  |


### PR DESCRIPTION
## Summary
- allow FakeIB to fill orders partially via per-symbol fractions
- add partial_fill scenario fixture with golden logs
- test e2e scenarios for partial fill path

## Testing
- `pytest tests/test_ibkr_provider.py -q`
- `pytest tests/test_order_executor.py::test_execute_orders_partial_fill_cancels_remaining tests/test_order_executor.py::test_execute_orders_partial_sell_proceeds_scale_buy tests/e2e/test_scenarios.py::test_scenarios -k partial_fill -q`
- `pre-commit run --files ibkr_etf_rebalancer/ibkr_provider.py ibkr_etf_rebalancer/scenario_runner.py tests/e2e/test_scenarios.py tests/e2e/fixtures/partial_fill.yml tests/e2e/golden/partial_fill/event_log_20240101T100000.json tests/e2e/golden/partial_fill/pre_trade_report_20240101T100000.csv tests/e2e/golden/partial_fill/post_trade_report_20240101T100000.csv tests/e2e/golden/partial_fill/pre_trade_report_20240101T100000.md tests/e2e/golden/partial_fill/post_trade_report_20240101T100000.md`


------
https://chatgpt.com/codex/tasks/task_e_68b254fa9e548320813c0cbc7c482d5f