### PR TITLE
test: assert no limit price for wide stale escalation

### DIFF
--- a/tests/e2e/test_scenarios.py
+++ b/tests/e2e/test_scenarios.py
@@ -195,6 +195,8 @@ def test_scenarios(fixture_path: Path) -> None:
             assert result2.fx_plan.est_rate == pytest.approx(scenario.prices["USD.CAD"])
         if fixture_path.stem == "wide_stale_keep":
             assert all(_parse_order(e["order"])["limit_price"] is not None for e in placed)
+        if fixture_path.stem == "wide_stale_escalation":
+            assert all(_parse_order(e["order"])["limit_price"] is None for e in placed)
         if kill_path:
             assert placed == []
             return


### PR DESCRIPTION
## Summary
- ensure wide_stale_escalation scenario places only market orders by asserting `limit_price` is None

## Testing
- `pre-commit run --files tests/e2e/test_scenarios.py`
- `pytest -q tests/e2e/test_scenarios.py::test_scenarios`


------
https://chatgpt.com/codex/tasks/task_e_68b25ae0d2e4832091ccaff14943e2c6