### PR TITLE
test: verify spread-aware limit prices

### DIFF
--- a/tests/e2e/test_scenarios.py
+++ b/tests/e2e/test_scenarios.py
@@ -224,6 +224,14 @@ def test_scenarios(fixture_path: Path) -> None:
                 else info["symbol"]
             )
             quote = scenario.quotes[key]
+            if fixture_path.stem == "spread_aware_limits":
+                assert info["limit_price"] is not None
+                if info["side"] == "BUY":
+                    assert quote.ask is not None
+                    assert info["limit_price"] == pytest.approx(quote.ask)
+                else:
+                    assert quote.bid is not None
+                    assert info["limit_price"] == pytest.approx(quote.bid)
             if info["sec_type"] == "CASH":
                 if info["limit_price"] is not None:
                     if info["side"] == "BUY":


### PR DESCRIPTION
## Summary
- validate that spread-aware limit orders use the opposite quote side

## Testing
- `pytest -q tests/e2e/test_scenarios.py::test_scenarios`


------
https://chatgpt.com/codex/tasks/task_e_68b25d06b8f08320a8e8cbd4af8a6a44