### PR TITLE
feat: add rebalance CLI command with execution tests

### DIFF
--- a/ibkr_etf_rebalancer/app.py
+++ b/ibkr_etf_rebalancer/app.py
@@ -38,18 +38,32 @@ from __future__ import annotations
 
 import csv
 from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
 from pathlib import Path
-from typing import Iterable
+from types import SimpleNamespace
+from typing import Iterable, Any, Mapping, cast
 
 import typer
 
+from . import safety
 from .account_state import compute_account_state
 from .config import load_config
-from .ibkr_provider import IBKRProviderOptions
-from .order_executor import OrderExecutionOptions
+from .ibkr_provider import (
+    IBKRProvider,
+    IBKRProviderOptions,
+    FakeIB,
+    Contract,
+    OrderSide,
+)
+from .order_builder import build_fx_order, build_orders
+from .order_executor import OrderExecutionOptions, OrderExecutionResult, execute_orders
 from .portfolio_loader import load_portfolios
-from .reporting import generate_pre_trade_report
+from .pricing import IBKRQuoteProvider
+from .rebalance_engine import plan_rebalance_with_fx
+from .reporting import generate_post_trade_report, generate_pre_trade_report
 from .target_blender import blend_targets
+from .util import from_bps
 
 
 app = typer.Typer(help="Utilities for running pre-trade reports and scenarios")
@@ -121,6 +135,19 @@ def main(
 
     # Store the options on the Typer context so subcommands can access them.
     ctx.obj = options
+
+
+def _connect_ibkr(options: IBKRProviderOptions) -> IBKRProvider:
+    """Return a connected :class:`IBKRProvider` instance.
+
+    The default implementation uses :class:`FakeIB` which is sufficient for
+    tests.  This helper is intentionally tiny so tests can monkeypatch it to
+    provide a preconfigured provider.
+    """
+
+    ib = FakeIB(options=options)
+    ib.connect()
+    return cast(IBKRProvider, ib)
 
 
 def _parse_cash(values: Iterable[str]) -> dict[str, float]:
@@ -221,6 +248,179 @@ def pre_trade(
         typer.echo(f"Markdown report written to {md_path}")
     else:  # pragma: no cover - defensive
         typer.echo(result.to_string(index=False))
+
+
+@app.command("rebalance")
+def rebalance(
+    ctx: typer.Context,
+    config: Path = typer.Option(..., exists=True, readable=True, help="Path to INI config file"),
+    portfolios: Path = typer.Option(
+        ..., exists=True, readable=True, help="CSV describing model portfolios"
+    ),
+    output_dir: Path | None = typer.Option(
+        None, "--output-dir", "-o", help="Directory for generated reports"
+    ),
+) -> None:
+    """Execute a full rebalance against the configured broker."""
+
+    options: CLIOptions = ctx.obj if isinstance(ctx.obj, CLIOptions) else CLIOptions()
+    cfg = load_config(config)
+
+    safety.check_kill_switch(cfg.safety.kill_switch_file)
+    safety.ensure_paper_trading(options.paper, options.live)
+    if cfg.safety.require_confirm:
+        safety.require_confirmation("Proceed with rebalancing?", options.yes)
+
+    ib_options = IBKRProviderOptions(
+        paper=options.paper,
+        live=options.live,
+        dry_run=options.dry_run,
+        kill_switch=cfg.safety.kill_switch_file,
+    )
+    ib = _connect_ibkr(ib_options)
+    quote_provider = IBKRQuoteProvider(ib)
+
+    portfolios_data = load_portfolios(
+        portfolios,
+        allow_margin=cfg.rebalance.allow_margin,
+        max_leverage=cfg.rebalance.max_leverage,
+    )
+    blend = blend_targets(portfolios_data, cfg.models)
+
+    positions: Mapping[str, float] = {
+        p.contract.symbol: p.quantity for p in ib.get_positions() if p.quantity != 0
+    }
+    symbols = set(blend.weights) | set(positions)
+    prices = {
+        sym: quote_provider.get_price(sym, cfg.pricing.price_source, cfg.pricing.fallback_to_snapshot)
+        for sym in symbols
+    }
+    cash_balances = {
+        av.currency: av.value
+        for av in ib.get_account_values()
+        if av.tag == "CashBalance" and av.currency
+    }
+    snapshot = compute_account_state(
+        positions,
+        prices,
+        cash_balances,
+        cash_buffer_pct=cfg.rebalance.cash_buffer_pct,
+    )
+
+    report_dir = output_dir or Path(cfg.io.report_dir)
+    as_of = datetime.now(timezone.utc)
+    pre_df, pre_csv, pre_md = cast(
+        tuple[Any, Path, Path],
+        generate_pre_trade_report(
+            blend.weights,
+            snapshot.weights,
+            prices,
+            snapshot.total_equity,
+            output_dir=report_dir,
+            as_of=as_of,
+            net_liq=snapshot.total_equity,
+            cash_balances=snapshot.cash_by_currency,
+            cash_buffer=(
+                snapshot.usd_cash * cfg.rebalance.cash_buffer_pct / 100.0
+                if cfg.rebalance.cash_buffer_pct
+                else None
+            ),
+            min_order=cfg.rebalance.min_order_usd,
+        ),
+    )
+
+    plan, fx_plan = plan_rebalance_with_fx(
+        blend.weights,
+        snapshot.weights,
+        prices,
+        snapshot.total_equity,
+        fx_cfg=cfg.fx,
+        quote_provider=quote_provider,
+        pricing_cfg=cfg.pricing,
+        funding_cash=snapshot.cash_by_currency.get("CAD", 0.0),
+        bands=from_bps(cfg.rebalance.per_holding_band_bps),
+        min_order=cfg.rebalance.min_order_usd,
+        max_leverage=cfg.rebalance.max_leverage,
+        cash_buffer_pct=cfg.rebalance.cash_buffer_pct,
+        maintenance_buffer_pct=cfg.rebalance.maintenance_buffer_pct,
+        allow_fractional=cfg.rebalance.allow_fractional,
+        trigger_mode=cfg.rebalance.trigger_mode,
+        portfolio_total_band_bps=cfg.rebalance.portfolio_total_band_bps,
+        allow_margin=cfg.rebalance.allow_margin,
+    )
+
+    if fx_plan.need_fx:
+        prices[fx_plan.pair.split(".")[0]] = fx_plan.est_rate
+
+    order_quotes = {sym: quote_provider.get_quote(sym) for sym in plan.orders}
+    contracts = {sym: ib.resolve_contract(Contract(symbol=sym)) for sym in plan.orders}
+    order_cfg = SimpleNamespace(**cfg.rebalance.model_dump(), limits=cfg.limits)
+    orders = build_orders(
+        plan.orders,
+        order_quotes,
+        order_cfg,
+        contracts,
+        allow_fractional=cfg.rebalance.allow_fractional,
+        allow_margin=cfg.rebalance.allow_margin,
+        prefer_rth=cfg.rebalance.prefer_rth,
+    )
+    sell_orders = [o for o in orders if o.side is OrderSide.SELL]
+    buy_orders = [o for o in orders if o.side is OrderSide.BUY]
+    fx_orders = []
+    if fx_plan.need_fx:
+        fx_sym, fx_cur = fx_plan.pair.split(".", 1)
+        fx_contract = ib.resolve_contract(
+            Contract(symbol=fx_sym, sec_type="CASH", currency=fx_cur, exchange=fx_plan.route)
+        )
+        fx_orders = [build_fx_order(fx_plan, fx_contract, prefer_rth=cfg.rebalance.prefer_rth)]
+
+    execution = execute_orders(
+        ib,
+        fx_orders=fx_orders,
+        sell_orders=sell_orders,
+        buy_orders=buy_orders,
+        fx_plan=fx_plan,
+        options=OrderExecutionOptions(
+            report_only=options.report_only,
+            dry_run=options.dry_run,
+            yes=options.yes,
+            require_confirm=cfg.safety.require_confirm,
+            prefer_rth=cfg.rebalance.prefer_rth,
+        ),
+        max_leverage=cfg.rebalance.max_leverage,
+        allow_margin=cfg.rebalance.allow_margin,
+    )
+    fills: list[Any]
+    limit_prices: Mapping[str, float | None]
+    if isinstance(execution, OrderExecutionResult):
+        fills = execution.fills
+        limit_prices = execution.limit_prices
+    else:
+        fills = []
+        limit_prices = {}
+
+    post_df, post_csv, post_md = cast(
+        tuple[Any, Path, Path],
+        generate_post_trade_report(
+            blend.weights,
+            snapshot.weights,
+            prices,
+            snapshot.total_equity,
+            fills,
+            limit_prices,
+            output_dir=report_dir,
+            as_of=as_of,
+        ),
+    )
+
+    event_log_path = report_dir / f"event_log_{as_of.strftime('%Y%m%dT%H%M%S')}.json"
+    event_log_path.write_text(json.dumps(list(ib.event_log), default=str, indent=2))
+
+    typer.echo(f"Pre-trade CSV report written to {pre_csv}")
+    typer.echo(f"Pre-trade Markdown report written to {pre_md}")
+    typer.echo(f"Post-trade CSV report written to {post_csv}")
+    typer.echo(f"Post-trade Markdown report written to {post_md}")
+    typer.echo(f"Event log written to {event_log_path}")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,15 +1,40 @@
 """Integration tests for the Typer CLI."""
 
 from pathlib import Path
+from datetime import datetime, timezone
+import json
+import re
 
 import pytest
 from freezegun import freeze_time
 from typer.testing import CliRunner
 
 from ibkr_etf_rebalancer.app import app
+import ibkr_etf_rebalancer.app as app_module
+from ibkr_etf_rebalancer.ibkr_provider import (
+    AccountValue,
+    Contract,
+    FakeIB,
+    IBKRProviderOptions,
+    Position,
+)
+from ibkr_etf_rebalancer.pricing import Quote
 
 
 runner = CliRunner()
+
+_ORDER_RE = re.compile(
+    r"Contract\(symbol='(?P<symbol>[^']+)', sec_type='(?P<sec_type>[^']+)', currency='(?P<currency>[^']+)'"
+)
+_SIDE_RE = re.compile(r"OrderSide.(?P<side>BUY|SELL)")
+
+
+def _parse_order(text: str) -> dict[str, str]:
+    m = _ORDER_RE.search(text)
+    if not m:
+        raise AssertionError(f"cannot parse order: {text}")
+    side = _SIDE_RE.search(text)
+    return {"symbol": m.group("symbol"), "side": side.group("side") if side else ""}
 
 
 def _write_basic_files(tmp_path: Path) -> tuple[Path, Path, Path]:
@@ -43,6 +68,74 @@ cash_buffer_pct = 0
     positions.write_text("""symbol,quantity,price\nAAA,500,100\nBBB,625,80\n""")
 
     return config, portfolios, positions
+
+
+def _write_rebalance_files(tmp_path: Path) -> tuple[Path, Path]:
+    config = tmp_path / "config.ini"
+    config.write_text(
+        """
+[ibkr]
+account = DU123
+
+[models]
+SMURF = 0.5
+BADASS = 0.3
+GLTR = 0.2
+
+[rebalance]
+cash_buffer_pct = 0
+min_order_usd = 0.01
+
+[fx]
+enabled = true
+base_currency = USD
+funding_currencies = CAD
+wait_for_fill_seconds = 0
+min_fx_order_usd = 10
+
+[limits]
+[safety]
+[io]
+"""
+    )
+
+    portfolios = tmp_path / "portfolios.csv"
+    portfolios.write_text(
+        """portfolio,symbol,target_pct\nSMURF,AAA,50\nSMURF,BBB,50\nBADASS,AAA,50\nBADASS,BBB,50\nGLTR,AAA,50\nGLTR,BBB,50\n"""
+    )
+
+    return config, portfolios
+
+
+def _fake_ib() -> FakeIB:
+    now = datetime(2024, 1, 1, 15, 0, 0, tzinfo=timezone.utc)
+    contracts = {
+        "AAA": Contract(symbol="AAA"),
+        "BBB": Contract(symbol="BBB"),
+        "USD": Contract(symbol="USD", sec_type="CASH", currency="CAD", exchange="IDEALPRO"),
+    }
+    quotes = {
+        "AAA": Quote(bid=99.0, ask=101.0, ts=now),
+        "BBB": Quote(bid=49.0, ask=51.0, ts=now),
+        "USD": Quote(bid=1.34, ask=1.36, ts=now),
+    }
+    positions = [
+        Position(account="DU123", contract=contracts["AAA"], quantity=0, avg_price=100.0),
+        Position(account="DU123", contract=contracts["BBB"], quantity=50, avg_price=50.0),
+    ]
+    account_values = [
+        AccountValue(tag="CashBalance", value=0.0, currency="USD"),
+        AccountValue(tag="CashBalance", value=1000.0, currency="CAD"),
+    ]
+    ib = FakeIB(
+        options=IBKRProviderOptions(allow_market_orders=True),
+        contracts=contracts,
+        quotes=quotes,
+        account_values=account_values,
+        positions=positions,
+    )
+    ib.connect()
+    return ib
 
 
 def test_pre_trade_cli(tmp_path: Path) -> None:
@@ -133,3 +226,74 @@ def test_scenario_forces_paper(tmp_path: Path, flag: str) -> None:
         md = report_dir / "pre_trade_report_20240101T100000.md"
         assert csv.exists()
         assert md.exists()
+
+
+def test_rebalance_cli_dry_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config, portfolios = _write_rebalance_files(tmp_path)
+    monkeypatch.setattr(app_module, "_connect_ibkr", lambda opts: _fake_ib())
+    with freeze_time("2024-01-01 15:00:00"):
+        result = runner.invoke(
+            app,
+            [
+                "--dry-run",
+                "--yes",
+                "rebalance",
+                "--config",
+                str(config),
+                "--portfolios",
+                str(portfolios),
+                "--output-dir",
+                str(tmp_path),
+            ],
+        )
+    assert result.exit_code == 0
+
+
+@pytest.mark.parametrize("flag", ["--no-paper", "--live"])
+def test_rebalance_cli_paper_live_gating(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, flag: str
+) -> None:
+    config, portfolios = _write_rebalance_files(tmp_path)
+    monkeypatch.setattr(app_module, "_connect_ibkr", lambda opts: _fake_ib())
+    with freeze_time("2024-01-01 15:00:00"):
+        result = runner.invoke(
+            app,
+            [
+                "--yes",
+                flag,
+                "rebalance",
+                "--config",
+                str(config),
+                "--portfolios",
+                str(portfolios),
+                "--output-dir",
+                str(tmp_path),
+            ],
+        )
+    assert result.exit_code != 0
+
+
+def test_rebalance_cli_event_log_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config, portfolios = _write_rebalance_files(tmp_path)
+    monkeypatch.setattr(app_module, "_connect_ibkr", lambda opts: _fake_ib())
+    with freeze_time("2024-01-01 15:00:00"):
+        result = runner.invoke(
+            app,
+            [
+                "--yes",
+                "rebalance",
+                "--config",
+                str(config),
+                "--portfolios",
+                str(portfolios),
+                "--output-dir",
+                str(tmp_path),
+            ],
+        )
+    assert result.exit_code == 0
+    events = json.loads((tmp_path / "event_log_20240101T150000.json").read_text())
+    placed = [_parse_order(e["order"]) for e in events if e["type"] == "placed"]
+    assert [p["symbol"] for p in placed] == ["USD", "BBB", "AAA"]
+    assert [p["side"] for p in placed] == ["BUY", "SELL", "BUY"]


### PR DESCRIPTION
## Summary
- add `rebalance` command to CLI with full planning, FX, order building and execution
- include pre/post trade report generation and event log output
- test rebalance workflow including flag gating and FX→SELL→BUY sequencing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b26047aed4832089c09d245966021a