### PR TITLE
feat(cli): expose ib-rebalance entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 - Placeholder for upcoming changes.
 
+## [0.1.1] - 2025-08-30
+- feat: add `ib-rebalance` CLI entry point via project scripts.
+
 ## Phase 7
 - Document paper and live CLI examples in `workflow.md`.
 - Clarified Definition of Done in `plan.md` to include CHANGELOG entries and SRS acceptance-criteria references.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ib-trade"
-version = "0.1.0"
+version = "0.1.1"
 description = "Interactive Brokers trading utilities"
 requires-python = ">=3.11"
 dependencies = [
@@ -13,6 +13,9 @@ dependencies = [
     "pandas",
     "typer",
 ]
+
+[project.scripts]
+ib-rebalance = "ibkr_etf_rebalancer.app:app"
 
 [project.optional-dependencies]
 dev = [
@@ -27,6 +30,9 @@ dev = [
     "pandas-stubs",        
     "pyyaml",
 ]
+
+[tool.setuptools.packages.find]
+include = ["ibkr_etf_rebalancer"]
 
 [tool.black]
 line-length = 100

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from datetime import datetime, timezone
 import json
 import re
+import subprocess
 
 import pytest
 from freezegun import freeze_time
@@ -22,6 +23,15 @@ from ibkr_etf_rebalancer.pricing import Quote
 
 
 runner = CliRunner()
+
+
+def test_entry_point_help() -> None:
+    result = subprocess.run([
+        "ib-rebalance",
+        "--help",
+    ], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "Utilities for running pre-trade reports and scenarios" in result.stdout
 
 _ORDER_RE = re.compile(
     r"Contract\(symbol='(?P<symbol>[^']+)', sec_type='(?P<sec_type>[^']+)', currency='(?P<currency>[^']+)'"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,12 +26,17 @@ runner = CliRunner()
 
 
 def test_entry_point_help() -> None:
-    result = subprocess.run([
-        "ib-rebalance",
-        "--help",
-    ], capture_output=True, text=True)
+    result = subprocess.run(
+        [
+            "ib-rebalance",
+            "--help",
+        ],
+        capture_output=True,
+        text=True,
+    )
     assert result.returncode == 0
     assert "Utilities for running pre-trade reports and scenarios" in result.stdout
+
 
 _ORDER_RE = re.compile(
     r"Contract\(symbol='(?P<symbol>[^']+)', sec_type='(?P<sec_type>[^']+)', currency='(?P<currency>[^']+)'"


### PR DESCRIPTION
## Summary
- add `ib-rebalance` console script to `project.scripts`
- bump version to 0.1.1 and document in changelog
- test CLI entry point

## Testing
- `pip install -e .`
- `ib-rebalance --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b26683a77883208144fb6d3f3ada17