### PR TITLE
docs: document rebalance command and logging defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 ## [0.1.1] - 2025-08-30
 - feat: add `ib-rebalance` CLI entry point via project scripts.
 
+## Phase 8
+- feat(cli): add `rebalance` command for full end-to-end rebalances.
+- feat(package): publish `ib-rebalance` console script for packaging.
+- feat(logging): run-scoped log files with level and JSON format options. [SRS AC7][SRS AC10]
+
 ## Phase 7
 - Document paper and live CLI examples in `workflow.md`.
 - Clarified Definition of Done in `plan.md` to include CHANGELOG entries and SRS acceptance-criteria references.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Run tests:
 make test
 ```
 
-Example run of the application:
+Examples:
 
 ```bash
 python -m ibkr_etf_rebalancer.app pre-trade \
@@ -31,10 +31,32 @@ python -m ibkr_etf_rebalancer.app pre-trade \
     --output-dir reports
 ```
 
+To execute a full rebalance against the broker:
+
+```bash
+python -m ibkr_etf_rebalancer.app rebalance \
+    --config config.ini \
+    --portfolios portfolios.csv \
+    --output-dir reports
+```
+
+The package also installs an `ib-rebalance` console script providing the same
+commands.
+
 Global flags control behaviour: `--report-only`, `--dry-run`,
-`--paper/--no-paper` (paper is the default), `--live`, `--yes`, and
-`--scenario PATH` to execute a YAML-defined end-to-end scenario instead of
-loading CSV/INI inputs.
+`--paper/--no-paper` (paper is the default), `--live`, `--yes`,
+`--log-level`, `--log-json/--log-text`, and `--scenario PATH` to execute a
+YAML-defined end-to-end scenario instead of loading CSV/INI inputs.
+
+Each run writes a log file `run_<timestamp>.log` under `io.report_dir`
+(`reports/` by default) and tags log lines with a unique run identifier.
+Adjust verbosity with `--log-level` and switch to structured JSON output with
+`--log-json`.
+
+Safety defaults favour caution: the CLI refuses live orders unless
+`--live --yes` is supplied and `[safety].paper_only` is disabled. Presence of a
+kill switch file aborts execution, and confirmation prompts are enabled by
+default.
 
 The configuration file can include an `[fx]` section to plan CAD→USD conversions ahead of ETF trades. This feature lets you enable FX planning and set per-order limits and acceptable slippage:
 


### PR DESCRIPTION
## Summary
- document `rebalance` CLI command, logging options, and safety defaults
- add Phase 8 changelog entry for CLI, packaging, and logging [SRS AC7][SRS AC10]

## Testing
- `make lint` (fails: SyntaxError in tests/test_cli.py)
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b271d55e9883209e44000d7a5cf6c2