### PR TITLE
Add CLI version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ python -m ibkr_etf_rebalancer.app rebalance \
 ```
 
 The package also installs an `ib-rebalance` console script providing the same
-commands.
+commands. Display the installed version with `ib-rebalance --version`.
 
 Global flags control behaviour: `--report-only`, `--dry-run`,
 `--paper/--no-paper` (paper is the default), `--live`, `--yes`,
 `--log-level`, `--log-json/--log-text`, `--kill-switch PATH` to override the
 default kill switch file, and `--scenario PATH` to execute a YAML-defined
-end-to-end scenario instead of loading CSV/INI inputs.
+end-to-end scenario instead of loading CSV/INI inputs. Use `--version` to print the
+installed package version and exit.
 
 Each run writes a log file `run_<timestamp>.log` under `io.report_dir`
 (`reports/` by default) and tags log lines with a unique run identifier.

--- a/ibkr_etf_rebalancer/app.py
+++ b/ibkr_etf_rebalancer/app.py
@@ -41,6 +41,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 import json
 import logging
+import importlib.metadata
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Iterable, Any, Mapping, cast
@@ -71,6 +72,13 @@ from .logging_utils import setup_logging
 app = typer.Typer(help="Utilities for running pre-trade reports and scenarios")
 
 
+def _version_callback(value: bool) -> None:
+    """Print the package version and exit."""
+    if value:
+        typer.echo(importlib.metadata.version("ib-trade"))
+        raise typer.Exit()
+
+
 @dataclass
 class CLIOptions:
     """Global command line flags routed to downstream components."""
@@ -88,6 +96,13 @@ class CLIOptions:
 @app.callback(invoke_without_command=True)
 def main(
     ctx: typer.Context,
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show the package version and exit",
+    ),
     report_only: bool = typer.Option(
         False, "--report-only", help="Generate reports without placing orders"
     ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "ib-trade"
 version = "0.1.1"
 description = "Interactive Brokers trading utilities"
+readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "ib_async",
@@ -15,7 +16,7 @@ dependencies = [
 ]
 
 [project.scripts]
-ib-rebalance = "ibkr_etf_rebalancer.app:app"
+ib-rebalance = "ibkr_etf_rebalancer.app:app"  # CLI; run `ib-rebalance --version` for version info
 
 [project.optional-dependencies]
 dev = [

--- a/tests/test_version_flag.py
+++ b/tests/test_version_flag.py
@@ -1,0 +1,13 @@
+import importlib.metadata
+import subprocess
+
+
+def test_version_flag_prints_current_version() -> None:
+    expected = importlib.metadata.version("ib-trade")
+    result = subprocess.run(
+        ["ib-rebalance", "--version"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == expected


### PR DESCRIPTION
## Summary
- add `--version` flag to Typer CLI that prints the `ib-trade` package version
- document how to show the version in README and project metadata
- test that `ib-rebalance --version` outputs the current version

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b27f34f3d88320b9c3d44d9550b711