### PR TITLE
Add CLI error handling and exit codes

### DIFF
--- a/ibkr_etf_rebalancer/errors.py
+++ b/ibkr_etf_rebalancer/errors.py
@@ -1,0 +1,27 @@
+"""Custom exceptions and exit codes for the Typer CLI."""
+
+from __future__ import annotations
+
+# Specific exit codes for each error category.  These are simple integers so the
+# tests and CLI can reference them without importing ``os`` on every platform.
+CONFIG_IO_EXIT_CODE = 2
+SAFETY_EXIT_CODE = 3
+RUNTIME_EXIT_CODE = 4
+UNKNOWN_EXIT_CODE = 1
+
+
+class ConfigIOError(Exception):
+    """Raised when configuration or I/O errors occur."""
+
+
+class SafetyError(Exception):
+    """Raised when a safety related issue is encountered."""
+
+
+class RuntimeAppError(Exception):
+    """Raised for runtime processing errors."""
+
+
+class UnknownAppError(Exception):
+    """Raised for unexpected errors."""
+

--- a/ibkr_etf_rebalancer/errors.py
+++ b/ibkr_etf_rebalancer/errors.py
@@ -24,4 +24,3 @@ class RuntimeAppError(Exception):
 
 class UnknownAppError(Exception):
     """Raised for unexpected errors."""
-


### PR DESCRIPTION
## Summary
- add dedicated ConfigIOError, SafetyError, RuntimeAppError, UnknownAppError with mapped exit codes
- wrap CLI commands to translate these exceptions into typer.Exit codes
- test that each exception category returns expected exit code

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b282eb7d548320b2a2881963bfbd8d