### PR TITLE
Fix Result import in CLI tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,8 @@ import subprocess
 
 import pytest
 from freezegun import freeze_time
-from typer.testing import CliRunner, Result
+from typer.testing import CliRunner
+from click.testing import Result
 
 from ibkr_etf_rebalancer.app import app
 import ibkr_etf_rebalancer.app as app_module


### PR DESCRIPTION
## Summary
- import Result from click.testing instead of typer.testing in tests/test_cli.py

## Testing
- `mypy --install-types --non-interactive .`


------
https://chatgpt.com/codex/tasks/task_e_68b28ca2e1c4832092558800e3926f58