### PR TITLE
Support environment variable config overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ default kill switch file, and `--scenario PATH` to execute a YAML-defined
 end-to-end scenario instead of loading CSV/INI inputs. Use `--version` to print the
 installed package version and exit.
 
+### Configuration precedence
+
+Configuration values are loaded from the INI file provided via `--config`. They
+may be overridden by environment variables named
+`IBKR_ETF_REBALANCER__SECTION__KEY` and finally by CLI options. Precedence is,
+from lowest to highest: INI file, environment variables, CLI options.
+
+For example, to override `[ibkr].account` from the environment:
+
+```bash
+export IBKR_ETF_REBALANCER__IBKR__ACCOUNT=DU999
+```
+
 Each run writes a log file `run_<timestamp>.log` under `io.report_dir`
 (`reports/` by default) and tags log lines with a unique run identifier.
 Adjust verbosity with `--log-level` and switch to structured JSON output with


### PR DESCRIPTION
## Summary
- merge IBKR_ETF_REBALANCER__* environment variables into config before CLI overrides
- document configuration precedence and env var naming in README
- test that env vars override INI values

## Testing
- `ruff check ibkr_etf_rebalancer/config.py tests/test_config.py`
- `black --check ibkr_etf_rebalancer/config.py tests/test_config.py`
- `mypy ibkr_etf_rebalancer/config.py`
- `pytest tests/test_config.py::test_env_var_overrides_ini tests/test_config.py::test_env_var_parsing -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3125b9fcc8320b73dea65724f47a4