### PR TITLE
Set unknown exit code to 5

### DIFF
--- a/ibkr_etf_rebalancer/app.py
+++ b/ibkr_etf_rebalancer/app.py
@@ -49,7 +49,7 @@ from typing import Iterable, Any, Mapping, cast, Callable, TypeVar
 import typer
 
 from . import safety
-from .errors import ConfigError, SafetyError, RuntimeError, ExitCode
+from .errors import ConfigError, SafetyError, RuntimeError, UnknownError, ExitCode
 from .account_state import compute_account_state
 from .config import load_config
 from .ibkr_provider import (
@@ -334,6 +334,8 @@ def pre_trade(
         raise typer.Exit(code=int(ExitCode.SAFETY))
     except RuntimeError:
         raise typer.Exit(code=int(ExitCode.RUNTIME))
+    except UnknownError:
+        raise typer.Exit(code=int(ExitCode.UNKNOWN))
     except Exception:
         raise typer.Exit(code=int(ExitCode.UNKNOWN))
 
@@ -539,6 +541,8 @@ def rebalance(
         raise typer.Exit(code=int(ExitCode.SAFETY))
     except RuntimeError:
         raise typer.Exit(code=int(ExitCode.RUNTIME))
+    except UnknownError:
+        raise typer.Exit(code=int(ExitCode.UNKNOWN))
     except Exception:
         raise typer.Exit(code=int(ExitCode.UNKNOWN))
 

--- a/ibkr_etf_rebalancer/errors.py
+++ b/ibkr_etf_rebalancer/errors.py
@@ -24,10 +24,10 @@ class UnknownError(Exception):
 class ExitCode(IntEnum):
     """Exit codes for different error categories."""
 
-    UNKNOWN = 1
     CONFIG = 2
     SAFETY = 3
     RUNTIME = 4
+    UNKNOWN = 5
 
 
 __all__ = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -609,4 +609,4 @@ def test_cli_runtime_error_exit_code(tmp_path: Path, monkeypatch: pytest.MonkeyP
 
 def test_cli_unknown_error_exit_code(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     result = _invoke_with_exception(tmp_path, monkeypatch, UnknownError("oops"))
-    assert result.exit_code == ExitCode.UNKNOWN
+    assert result.exit_code == 5  # ExitCode.UNKNOWN


### PR DESCRIPTION
## Summary
- move `ExitCode.UNKNOWN` to value 5
- explicitly catch `UnknownError` in CLI and exit with new code
- adjust CLI tests to expect unknown errors exit with code 5

## Testing
- `ruff check ibkr_etf_rebalancer/errors.py ibkr_etf_rebalancer/app.py tests/test_cli.py`
- `black --check ibkr_etf_rebalancer/errors.py ibkr_etf_rebalancer/app.py tests/test_cli.py`
- `pytest tests/test_cli.py::test_cli_config_error_exit_code tests/test_cli.py::test_cli_safety_error_exit_code tests/test_cli.py::test_cli_runtime_error_exit_code tests/test_cli.py::test_cli_unknown_error_exit_code -q`

------
https://chatgpt.com/codex/tasks/task_e_68b315fd3dc48320bb163717d16600b4