### PR TITLE
Enforce kill switch and confirmations for live trading

### DIFF
--- a/ibkr_etf_rebalancer/ibkr_provider.py
+++ b/ibkr_etf_rebalancer/ibkr_provider.py
@@ -429,8 +429,9 @@ class FakeIB:
 
     # ------------------------------------------------------------------
     def place_order(self, order: Order) -> str:
-        safety.check_kill_switch(self.options.kill_switch)
-        safety.ensure_paper_trading(self.options.paper, self.options.live)
+        safety.check_kill_switch(self.options.kill_switch, live=self.options.live)
+        if not self.options.live:
+            safety.ensure_paper_trading(self.options.paper, self.options.live)
 
         if order.order_type is OrderType.MARKET and not self.options.allow_market_orders:
             raise RuntimeError("market orders not allowed")

--- a/ibkr_etf_rebalancer/order_executor.py
+++ b/ibkr_etf_rebalancer/order_executor.py
@@ -174,8 +174,9 @@ def execute_orders(
     logger = logging.getLogger(__name__)
     options = options or OrderExecutionOptions()
 
-    safety.check_kill_switch(ib.options.kill_switch)
-    safety.ensure_paper_trading(ib.options.paper, ib.options.live)
+    safety.check_kill_switch(ib.options.kill_switch, live=ib.options.live)
+    if not ib.options.live:
+        safety.ensure_paper_trading(ib.options.paper, ib.options.live)
     safety.ensure_regular_trading_hours(datetime.now(timezone.utc), options.prefer_rth)
     if options.require_confirm:
         safety.require_confirmation("Proceed with order placement?", options.yes)

--- a/ibkr_etf_rebalancer/safety.py
+++ b/ibkr_etf_rebalancer/safety.py
@@ -16,14 +16,17 @@ from zoneinfo import ZoneInfo
 from .errors import SafetyError
 
 
-def check_kill_switch(path: str | Path | None) -> None:
-    """Abort if a *kill switch* file exists."""
+def check_kill_switch(path: str | Path | None, live: bool = False) -> None:
+    """Validate the state of the *kill switch* file."""
 
-    if path is None:
-        return
-    kill_switch = Path(path).expanduser()
-    if kill_switch.exists():
-        raise SafetyError(f"kill switch engaged: {kill_switch}")
+    kill_switch = Path(path).expanduser() if path is not None else None
+
+    if live:
+        if kill_switch is None or not kill_switch.exists():
+            raise SafetyError(f"kill switch file missing: {kill_switch}")
+    else:
+        if kill_switch is not None and kill_switch.exists():
+            raise SafetyError(f"kill switch engaged: {kill_switch}")
 
 
 def ensure_paper_trading(paper: bool, live: bool) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,7 +90,9 @@ def _write_basic_files(tmp_path: Path, report_dir: Path | None = None) -> tuple[
     return config, portfolios, positions
 
 
-def _write_rebalance_files(tmp_path: Path, report_dir: Path | None = None) -> tuple[Path, Path]:
+def _write_rebalance_files(
+    tmp_path: Path, report_dir: Path | None = None, paper_only: bool = True
+) -> tuple[Path, Path]:
     config = tmp_path / "config.ini"
     report_dir_line = f"report_dir = {report_dir}\n" if report_dir else ""
     config.write_text(
@@ -111,6 +113,7 @@ def _write_rebalance_files(tmp_path: Path, report_dir: Path | None = None) -> tu
         "min_fx_order_usd = 10\n\n"
         "[limits]\n"
         "[safety]\n"
+        f"paper_only = {'true' if paper_only else 'false'}\n"
         "[io]\n" + report_dir_line
     )
 
@@ -375,9 +378,8 @@ def test_rebalance_cli_as_of(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert log.exists()
 
 
-@pytest.mark.parametrize("flag", ["--no-paper", "--live"])
-def test_rebalance_cli_paper_live_gating(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, flag: str
+def test_rebalance_cli_no_paper_gating(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     config, portfolios = _write_rebalance_files(tmp_path)
     monkeypatch.setattr(app_module, "_connect_ibkr", lambda opts: _fake_ib())
@@ -386,7 +388,94 @@ def test_rebalance_cli_paper_live_gating(
             app,
             [
                 "--yes",
-                flag,
+                "--no-paper",
+                "rebalance",
+                "--config",
+                str(config),
+                "--portfolios",
+                str(portfolios),
+                "--output-dir",
+                str(tmp_path),
+            ],
+        )
+    assert result.exit_code != 0
+
+
+def test_rebalance_cli_live_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config, portfolios = _write_rebalance_files(tmp_path, report_dir=tmp_path, paper_only=False)
+    kill = tmp_path / "KILL_SWITCH"
+    kill.write_text("go")
+
+    from dataclasses import replace
+
+    def _connect(opts: IBKRProviderOptions) -> FakeIB:
+        ib = _fake_ib()
+        ib.options = replace(opts, allow_market_orders=True)
+        return ib
+
+    monkeypatch.setattr(app_module, "_connect_ibkr", _connect)
+    with freeze_time("2024-01-01 15:00:00"):
+        result = runner.invoke(
+            app,
+            [
+                "--live",
+                "--yes",
+                "--kill-switch",
+                str(kill),
+                "rebalance",
+                "--config",
+                str(config),
+                "--portfolios",
+                str(portfolios),
+                "--output-dir",
+                str(tmp_path),
+            ],
+        )
+    assert result.exit_code == 0
+
+
+def test_rebalance_cli_live_requires_yes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config, portfolios = _write_rebalance_files(tmp_path, paper_only=False)
+    kill = tmp_path / "KILL_SWITCH"
+    kill.write_text("go")
+    monkeypatch.setattr(app_module, "_connect_ibkr", lambda opts: _fake_ib())
+    with freeze_time("2024-01-01 15:00:00"):
+        result = runner.invoke(
+            app,
+            [
+                "--live",
+                "--kill-switch",
+                str(kill),
+                "rebalance",
+                "--config",
+                str(config),
+                "--portfolios",
+                str(portfolios),
+                "--output-dir",
+                str(tmp_path),
+            ],
+        )
+    assert result.exit_code != 0
+
+
+def test_rebalance_cli_live_requires_kill_switch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config, portfolios = _write_rebalance_files(tmp_path, paper_only=False)
+    kill = tmp_path / "KILL_SWITCH"
+    monkeypatch.setattr(app_module, "_connect_ibkr", lambda opts: _fake_ib())
+    with freeze_time("2024-01-01 15:00:00"):
+        result = runner.invoke(
+            app,
+            [
+                "--live",
+                "--yes",
+                "--kill-switch",
+                str(kill),
                 "rebalance",
                 "--config",
                 str(config),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -378,9 +378,7 @@ def test_rebalance_cli_as_of(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert log.exists()
 
 
-def test_rebalance_cli_no_paper_gating(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_rebalance_cli_no_paper_gating(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     config, portfolios = _write_rebalance_files(tmp_path)
     monkeypatch.setattr(app_module, "_connect_ibkr", lambda opts: _fake_ib())
     with freeze_time("2024-01-01 15:00:00"):
@@ -401,9 +399,7 @@ def test_rebalance_cli_no_paper_gating(
     assert result.exit_code != 0
 
 
-def test_rebalance_cli_live_success(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_rebalance_cli_live_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     config, portfolios = _write_rebalance_files(tmp_path, report_dir=tmp_path, paper_only=False)
     kill = tmp_path / "KILL_SWITCH"
     kill.write_text("go")
@@ -436,9 +432,7 @@ def test_rebalance_cli_live_success(
     assert result.exit_code == 0
 
 
-def test_rebalance_cli_live_requires_yes(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_rebalance_cli_live_requires_yes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     config, portfolios = _write_rebalance_files(tmp_path, paper_only=False)
     kill = tmp_path / "KILL_SWITCH"
     kill.write_text("go")


### PR DESCRIPTION
## Summary
- require kill-switch file, --live and --yes for live rebalances
- make kill switch check live-aware and bypass paper enforcement when live
- add CLI tests for live mode success and failure cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b316cc4ee083208a683357de1a5fe2