### PR TITLE
Add example configs and expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,26 @@
 
 This project automates rebalancing of ETF portfolios via Interactive Brokers. It loads model portfolios, blends them according to configured weights, compares current holdings, and generates orders to bring the account back to target allocations.
 
+> **Warning:** Trading is risky. Use at your own risk. Always test in paper mode and configure a kill switch file before placing live orders.
+> Orders are priced with spread-aware limits to avoid crossing the bid/ask spread.
+
 ## Project Status
 
 Development is being tracked in phased checklists. Phases 0–7 are implemented: Phase 4 introduces FX planning for CAD→USD conversions, Phase 5 adds provider abstractions (`IBKRProvider`, `FakeIB`, `LiveIB`) and the `IBKRQuoteProvider` for market data, enabling account snapshot retrieval and pacing safeguards, Phase 6 delivers the order builder and executor with spread-aware limit pricing, FX→SELL→BUY sequencing, and safety rails, and Phase 7 adds an end-to-end scenario runner for offline workflow verification. Subsequent phases are planned but not yet executed.
+
+## Installation
+
+For development install:
+
+```bash
+pip install -e .
+```
+
+For runtime use:
+
+```bash
+pip install ib-trade
+```
 
 ## Commands
 
@@ -20,12 +37,14 @@ Run tests:
 make test
 ```
 
-Examples:
+Quick start:
+
+Use the sample files under `examples/`.
 
 ```bash
 python -m ibkr_etf_rebalancer.app pre-trade \
-    --config config.ini \
-    --portfolios portfolios.csv \
+    --config examples/settings.ini \
+    --portfolios examples/portfolios.csv \
     --positions positions.csv \
     --cash USD=10000 \
     --output-dir reports
@@ -35,11 +54,24 @@ To execute a full rebalance against the broker:
 
 ```bash
 python -m ibkr_etf_rebalancer.app rebalance \
-    --config config.ini \
-    --portfolios portfolios.csv \
+    --config examples/settings.ini \
+    --portfolios examples/portfolios.csv \
     --output-dir reports
 ```
 
+Or run an offline scenario:
+
+```bash
+ib-rebalance --scenario examples/scenario.yml --output-dir reports
+```
+
+Portfolios CSV schema:
+
+- columns: `portfolio`, `symbol`, `target_pct` (percent values like `40` for 40%).
+- Include an optional `CASH` row with a negative `target_pct` to model borrowed cash.
+- Extra columns such as `note`, `min_lot`, or `exchange` are ignored.
+
+`settings.ini` groups keys under sections like `[ibkr]`, `[rebalance]`, `[fx]`, `[limits]`, `[safety]`, and `[io]`. See `examples/settings.ini` for a minimal configuration.
 The package also installs an `ib-rebalance` console script providing the same
 commands. Display the installed version with `ib-rebalance --version`.
 

--- a/examples/portfolios.csv
+++ b/examples/portfolios.csv
@@ -1,0 +1,7 @@
+portfolio,symbol,target_pct
+SMURF,SPY,60
+SMURF,AGG,40
+BADASS,VT,55
+BADASS,QQQ,50
+BADASS,CASH,-5
+GLTR,GLD,100

--- a/examples/scenario.yml
+++ b/examples/scenario.yml
@@ -1,0 +1,20 @@
+name: Demo scenario
+as_of: 2024-01-01T10:00:00Z
+prices:
+  SPY: 400.0
+  AGG: 100.0
+quotes:
+  SPY:
+    bid: 399.5
+    ask: 400.5
+  AGG:
+    bid: 99.5
+    ask: 100.5
+positions:
+  SPY: 60
+  AGG: 40
+cash:
+  USD: 1000.0
+target_weights:
+  SPY: 0.6
+  AGG: 0.4

--- a/examples/settings.ini
+++ b/examples/settings.ini
@@ -1,0 +1,28 @@
+[ibkr]
+account = DU123
+host = localhost
+port = 7497
+client_id = 1
+
+[rebalance]
+per_holding_band_bps = 50
+min_order_usd = 500
+allow_margin = false
+
+[fx]
+enabled = false
+base_currency = USD
+funding_currencies = CAD
+
+[limits]
+style = spread_aware
+buy_offset_frac = 0.25
+sell_offset_frac = 0.25
+
+[safety]
+paper_only = true
+kill_switch_file = KILL_SWITCH
+
+[io]
+report_dir = reports
+log_level = INFO


### PR DESCRIPTION
## Summary
- add `examples` directory with sample portfolios, settings, and scenario files
- expand README with installation instructions, quick start examples, and CSV/INI schema notes
- highlight safety disclaimer, kill-switch requirement, and spread-aware pricing

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b31ffd74508320a59e95c0c8d464df