### PR TITLE
feat(cli): add report command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 - Placeholder for upcoming changes.
+### Added
+- feat(cli): add `report` command to display existing reports.
 
 ## [0.1.1] - 2025-08-30
 - feat: add `ib-rebalance` CLI entry point via project scripts.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Or run an offline scenario:
 ib-rebalance --scenario examples/scenario.yml --output-dir reports
 ```
 
+Display a previously generated report:
+
+```bash
+ib-rebalance report --file reports/pre_trade_report_20240101T120000.csv
+```
+
 Example pre-trade report snippet (`pre_trade_report_<timestamp>.csv`):
 
 ```csv


### PR DESCRIPTION
## Summary
- add `report` CLI command to display CSV or Markdown reports
- document report command and update changelog
- test CLI report output for CSV and Markdown files

## Testing
- `pytest tests/test_cli.py::test_report_cli -q`
- `pytest tests/test_cli.py::test_pre_trade_cli -q`


------
https://chatgpt.com/codex/tasks/task_e_68b32a45963883208b0ef8618f2ec16e