### PR TITLE
feat: allow output-dir for scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ commands. Display the installed version with `ib-rebalance --version`.
 Global flags control behaviour: `--report-only`, `--dry-run`,
 `--paper/--no-paper` (paper is the default), `--live`, `--yes`,
 `--log-level`, `--log-json/--log-text`, `--kill-switch PATH` to override the
-default kill switch file, `--ask-bid-cap/--no-ask-bid-cap` to toggle the NBBO
-cap on limit prices, and `--scenario PATH` to execute a YAML-defined
-end-to-end scenario instead of loading CSV/INI inputs. Use `--version` to print the
-installed package version and exit.
+default kill switch file, `--output-dir PATH` to choose a report directory,
+`--ask-bid-cap/--no-ask-bid-cap` to toggle the NBBO cap on limit prices, and
+`--scenario PATH` to execute a YAML-defined end-to-end scenario instead of loading
+CSV/INI inputs. Use `--version` to print the installed package version and exit.
 
 To change the NBBO cap from the command line:
 

--- a/ibkr_etf_rebalancer/app.py
+++ b/ibkr_etf_rebalancer/app.py
@@ -134,6 +134,12 @@ def main(
         readable=False,
         help="Override path to kill switch file",
     ),
+    output_dir: Path | None = typer.Option(
+        None,
+        "--output-dir",
+        "-o",
+        help="Directory for generated reports",
+    ),
     scenario: Path | None = typer.Option(
         None,
         "--scenario",
@@ -172,7 +178,7 @@ def main(
         if cfg.safety.require_confirm:
             safety.require_confirmation("Proceed with scenario execution?", options.yes)
 
-        result = run_scenario(sc)
+        result = run_scenario(sc, output_dir=output_dir)
 
         typer.echo(f"Pre-trade CSV report written to {result.pre_report_csv}")
         typer.echo(f"Pre-trade Markdown report written to {result.pre_report_md}")

--- a/ibkr_etf_rebalancer/scenario_runner.py
+++ b/ibkr_etf_rebalancer/scenario_runner.py
@@ -54,7 +54,7 @@ class ScenarioRunResult:
 # ---------------------------------------------------------------------------
 
 
-def run_scenario(scenario: Scenario) -> ScenarioRunResult:
+def run_scenario(scenario: Scenario, output_dir: Path | None = None) -> ScenarioRunResult:
     """Execute *scenario* end-to-end using fakes only.
 
     The function performs the following high level steps:
@@ -73,8 +73,8 @@ def run_scenario(scenario: Scenario) -> ScenarioRunResult:
         cfg: AppConfig = scenario.app_config()
         as_of = scenario.as_of
         stamp = as_of.strftime("%Y%m%dT%H%M%S")
-        output_dir = Path(cfg.io.report_dir)
-        output_dir.mkdir(parents=True, exist_ok=True)
+        report_dir = output_dir or Path(cfg.io.report_dir)
+        report_dir.mkdir(parents=True, exist_ok=True)
 
         # ------------------------------------------------------------------
         # Quote and contract setup
@@ -181,7 +181,7 @@ def run_scenario(scenario: Scenario) -> ScenarioRunResult:
                 snapshot.weights,
                 scenario.prices,
                 snapshot.total_equity,
-                output_dir=output_dir,
+                output_dir=report_dir,
                 as_of=as_of,
                 net_liq=snapshot.total_equity,
                 cash_balances=snapshot.cash_by_currency,
@@ -269,12 +269,12 @@ def run_scenario(scenario: Scenario) -> ScenarioRunResult:
                 snapshot.total_equity,
                 execution.fills,
                 execution.limit_prices,
-                output_dir=output_dir,
+                output_dir=report_dir,
                 as_of=as_of,
             ),
         )
 
-        event_log_path = output_dir / f"event_log_{stamp}.json"
+        event_log_path = report_dir / f"event_log_{stamp}.json"
         event_log_path.write_text(json.dumps(list(ib.event_log), default=str, indent=2))
 
         return ScenarioRunResult(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -327,12 +327,15 @@ def test_scenario_flag(tmp_path: Path) -> None:
     fixture = Path(__file__).resolve().parent / "e2e/fixtures/no_trade_within_band.yml"
     scenario_path = tmp_path / "scenario.yml"
     scenario_path.write_text(fixture.read_text().replace("min_order_usd: 0", "min_order_usd: 1e-9"))
+    out_dir = tmp_path / "custom"
     with runner.isolated_filesystem(temp_dir=tmp_path):
-        result = runner.invoke(app, ["--yes", "--scenario", str(scenario_path)])
+        result = runner.invoke(
+            app,
+            ["--yes", "--output-dir", str(out_dir), "--scenario", str(scenario_path)],
+        )
         assert result.exit_code == 0
-        report_dir = Path("reports")
-        csv = report_dir / "pre_trade_report_20240101T100000.csv"
-        md = report_dir / "pre_trade_report_20240101T100000.md"
+        csv = out_dir / "pre_trade_report_20240101T100000.csv"
+        md = out_dir / "pre_trade_report_20240101T100000.md"
         assert csv.exists()
         assert md.exists()
 


### PR DESCRIPTION
## Summary
- accept `--output-dir` when running scenarios
- route the option through to `run_scenario`
- document global flag and cover via CLI test

## Testing
- `pytest tests/test_cli.py::test_scenario_flag tests/test_cli.py::test_scenario_forces_paper -q`

------
https://chatgpt.com/codex/tasks/task_e_68b332321f388320971091e46f2fedd1