### PR TITLE
feat: handle fx market holidays and DST

### DIFF
--- a/ibkr_etf_rebalancer/config.py
+++ b/ibkr_etf_rebalancer/config.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 from configparser import ConfigParser
 from typing import Any, Literal
+from datetime import date
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 
@@ -131,6 +132,10 @@ class FXConfig(BaseModel):
         5, ge=0, description="Pause before placing dependent ETF orders"
     )
     prefer_market_hours: bool = Field(False, description="Allow off-hours FX trading by default")
+    market_holidays: list[date] = Field(
+        default_factory=list,
+        description="Dates when the FX market is closed",
+    )
 
 
 class LimitsConfig(BaseModel):

--- a/tests/test_fx_engine.py
+++ b/tests/test_fx_engine.py
@@ -343,9 +343,7 @@ def test_is_fx_market_open_blocks_holidays() -> None:
     assert _is_fx_market_open(ts_next, holidays=[holiday]) is True
 
 
-def test_prefer_market_hours_blocks_holiday(
-    fresh_quote: Quote, fx_cfg: FXConfig
-) -> None:
+def test_prefer_market_hours_blocks_holiday(fresh_quote: Quote, fx_cfg: FXConfig) -> None:
     cfg = fx_cfg.model_copy(
         update={"prefer_market_hours": True, "market_holidays": [date(2024, 1, 1)]}
     )

--- a/tests/test_fx_engine.py
+++ b/tests/test_fx_engine.py
@@ -1,9 +1,9 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, date
 
 import pytest
 
 from ibkr_etf_rebalancer.config import FXConfig, PricingConfig
-from ibkr_etf_rebalancer.fx_engine import plan_fx_if_needed
+from ibkr_etf_rebalancer.fx_engine import plan_fx_if_needed, _is_fx_market_open
 from ibkr_etf_rebalancer.rebalance_engine import plan_rebalance_with_fx
 from ibkr_etf_rebalancer.pricing import Quote
 from ibkr_etf_rebalancer.util import from_bps
@@ -322,6 +322,41 @@ def test_prefer_market_hours_blocks_before_sunday_open(
         fx_quote=fresh_quote,
         cfg=cfg,
         now=sunday,
+    )
+    assert plan.need_fx is False
+    assert "outside market hours" in plan.reason
+
+
+def test_is_fx_market_open_handles_dst_boundary() -> None:
+    # July is in daylight saving time for New York. Market opens at 21:00 UTC.
+    before_open = datetime(2024, 7, 7, 20, 59, tzinfo=timezone.utc)
+    after_open = datetime(2024, 7, 7, 21, 1, tzinfo=timezone.utc)
+    assert _is_fx_market_open(before_open) is False
+    assert _is_fx_market_open(after_open) is True
+
+
+def test_is_fx_market_open_blocks_holidays() -> None:
+    holiday = date(2024, 1, 1)
+    ts = datetime(2024, 1, 1, 12, tzinfo=timezone.utc)
+    assert _is_fx_market_open(ts, holidays=[holiday]) is False
+    ts_next = datetime(2024, 1, 2, 12, tzinfo=timezone.utc)
+    assert _is_fx_market_open(ts_next, holidays=[holiday]) is True
+
+
+def test_prefer_market_hours_blocks_holiday(
+    fresh_quote: Quote, fx_cfg: FXConfig
+) -> None:
+    cfg = fx_cfg.model_copy(
+        update={"prefer_market_hours": True, "market_holidays": [date(2024, 1, 1)]}
+    )
+    new_year = datetime(2024, 1, 1, 12, tzinfo=timezone.utc)
+    plan = plan_fx_if_needed(
+        usd_needed=5_000,
+        usd_cash=0,
+        funding_cash=20_000,
+        fx_quote=fresh_quote,
+        cfg=cfg,
+        now=new_year,
     )
     assert plan.need_fx is False
     assert "outside market hours" in plan.reason


### PR DESCRIPTION
## Summary
- adjust FX market hours for DST by evaluating times in New York timezone
- allow a configurable list of FX market holidays
- add tests for DST boundaries and holiday closures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b34c05495c832089a7c10656daf474